### PR TITLE
Removing max_photons simulation strategies

### DIFF
--- a/cpiquasso/sampling/simulation_strategies/GaussianSimulationStrategy.py
+++ b/cpiquasso/sampling/simulation_strategies/GaussianSimulationStrategy.py
@@ -20,9 +20,9 @@ from .GaussianSimulationStrategyFast_wrapper import GaussianSimulationStrategyFa
 class GaussianSimulationStrategy(
     GaussianSimulationStrategy_wrapper
 ):
-    def __init__(self, covariance_matrix, m=None, fock_cutoff=5, max_photons=20):
+    def __init__(self, covariance_matrix, m=None, fock_cutoff=5):
 
-        super().__init__(covariance_matrix=covariance_matrix, m=m, fock_cutoff=fock_cutoff, max_photons=max_photons)
+        super().__init__(covariance_matrix=covariance_matrix, m=m, fock_cutoff=fock_cutoff)
 
 
     def simulate(self, samples_number: int = 1):
@@ -39,9 +39,9 @@ class GaussianSimulationStrategy(
 class GaussianSimulationStrategyFast(
     GaussianSimulationStrategyFast_wrapper
 ):
-    def __init__(self, covariance_matrix, m=None, fock_cutoff=5, max_photons=20):
+    def __init__(self, covariance_matrix, m=None, fock_cutoff=5):
 
-        super().__init__(covariance_matrix=covariance_matrix, m=m, fock_cutoff=fock_cutoff, max_photons=max_photons)
+        super().__init__(covariance_matrix=covariance_matrix, m=m, fock_cutoff=fock_cutoff)
 
 
     def simulate(self, samples_number: int = 1):

--- a/cpiquasso/sampling/simulation_strategies/GaussianSimulationStrategyFast_wrapper.cpp
+++ b/cpiquasso/sampling/simulation_strategies/GaussianSimulationStrategyFast_wrapper.cpp
@@ -29,13 +29,12 @@ typedef struct GaussianSimulationStrategyFast_wrapper {
 @param covariance_matrix The covariance matrix describing the gaussian state
 @param displacement The mean (displacement) of the Gaussian state
 @param cutoff the Fock basis truncation.
-@param max_photons specifies the maximum number of photons that can be counted in the output samples.
 @return Return with a void pointer pointing to an instance of N_Qubit_Decomposition class.
 */
 pic::GaussianSimulationStrategyFast*
-cerate_ChinHuhPermanentCalculator( pic::matrix &covariance_matrix_mtx, pic::matrix &displacement, const size_t& cutoff, const size_t& max_photons ) {
+create_ChinHuhPermanentCalculator( pic::matrix &covariance_matrix_mtx, pic::matrix &displacement, const size_t& cutoff ) {
 
-    return new pic::GaussianSimulationStrategyFast(covariance_matrix_mtx, displacement, cutoff, max_photons);
+    return new pic::GaussianSimulationStrategyFast(covariance_matrix_mtx, displacement, cutoff );
 
 }
 
@@ -116,17 +115,16 @@ static int
 GaussianSimulationStrategyFast_wrapper_init(GaussianSimulationStrategyFast_wrapper *self, PyObject *args, PyObject *kwds)
 {
     // The tuple of expected keywords
-    static char *kwlist[] = {(char*)"covariance_matrix", (char*)"m", (char*)"fock_cutoff", (char*)"max_photons", NULL};
+    static char *kwlist[] = {(char*)"covariance_matrix", (char*)"m", (char*)"fock_cutoff", NULL};
 
     // initiate variables for input arguments
     PyObject *covariance_matrix_arg = NULL;
     PyObject *m_arg = NULL;
     int fock_cutoff = 0;
-    int max_photons = 0;
 
     // parsing input arguments
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|OOii", kwlist,
-                                     &covariance_matrix_arg, &m_arg, &fock_cutoff, &max_photons))
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|OOi", kwlist,
+                                     &covariance_matrix_arg, &m_arg, &fock_cutoff ))
         return -1;
 
     // convert python object array to numpy C API array
@@ -161,7 +159,7 @@ GaussianSimulationStrategyFast_wrapper_init(GaussianSimulationStrategyFast_wrapp
     pic::matrix m_mtx = numpy2matrix(self->m);
 
     // create instance of class ChinHuhPermanentCalculator
-    self->simulation_strategy = cerate_ChinHuhPermanentCalculator( covariance_matrix_mtx, m_mtx, fock_cutoff , max_photons );
+    self->simulation_strategy = create_ChinHuhPermanentCalculator( covariance_matrix_mtx, m_mtx, fock_cutoff );
 
     return 0;
 }

--- a/cpiquasso/sampling/simulation_strategies/GaussianSimulationStrategy_wrapper.cpp
+++ b/cpiquasso/sampling/simulation_strategies/GaussianSimulationStrategy_wrapper.cpp
@@ -29,13 +29,12 @@ typedef struct GaussianSimulationStrategy_wrapper {
 @param covariance_matrix The covariance matrix describing the gaussian state
 @param displacement The mean (displacement) of the Gaussian state
 @param cutoff the Fock basis truncation.
-@param max_photons specifies the maximum number of photons that can be counted in the output samples.
 @return Return with a void pointer pointing to an instance of N_Qubit_Decomposition class.
 */
 pic::GaussianSimulationStrategy*
-cerate_ChinHuhPermanentCalculator( pic::matrix &covariance_matrix_mtx, pic::matrix &displacement, const size_t& cutoff, const size_t& max_photons ) {
+create_ChinHuhPermanentCalculator( pic::matrix &covariance_matrix_mtx, pic::matrix &displacement, const size_t& cutoff ) {
 
-    return new pic::GaussianSimulationStrategy(covariance_matrix_mtx, displacement, cutoff, max_photons);
+    return new pic::GaussianSimulationStrategy(covariance_matrix_mtx, displacement, cutoff);
 
 }
 
@@ -116,17 +115,16 @@ static int
 GaussianSimulationStrategy_wrapper_init(GaussianSimulationStrategy_wrapper *self, PyObject *args, PyObject *kwds)
 {
     // The tuple of expected keywords
-    static char *kwlist[] = {(char*)"covariance_matrix", (char*)"m", (char*)"fock_cutoff", (char*)"max_photons", NULL};
+    static char *kwlist[] = {(char*)"covariance_matrix", (char*)"m", (char*)"fock_cutoff", NULL};
 
     // initiate variables for input arguments
     PyObject *covariance_matrix_arg = NULL;
     PyObject *m_arg = NULL;
     int fock_cutoff = 0;
-    int max_photons = 0;
 
     // parsing input arguments
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|OOii", kwlist,
-                                     &covariance_matrix_arg, &m_arg, &fock_cutoff, &max_photons))
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|OOi", kwlist,
+                                     &covariance_matrix_arg, &m_arg, &fock_cutoff))
         return -1;
 
     // convert python object array to numpy C API array
@@ -161,7 +159,7 @@ GaussianSimulationStrategy_wrapper_init(GaussianSimulationStrategy_wrapper *self
     pic::matrix m_mtx = numpy2matrix(self->m);
 
     // create instance of class ChinHuhPermanentCalculator
-    self->simulation_strategy = cerate_ChinHuhPermanentCalculator( covariance_matrix_mtx, m_mtx, fock_cutoff , max_photons );
+    self->simulation_strategy = create_ChinHuhPermanentCalculator( covariance_matrix_mtx, m_mtx, fock_cutoff );
 
     return 0;
 }

--- a/cpiquasso/sampling/simulation_strategies/source/GaussianSimulationStrategy.cpp
+++ b/cpiquasso/sampling/simulation_strategies/source/GaussianSimulationStrategy.cpp
@@ -87,7 +87,6 @@ GaussianSimulationStrategy::GaussianSimulationStrategy() {
 
 
     cutoff = 0;
-    max_photons = 0;
 
 #ifdef __MPI__
     // Get the number of processes
@@ -105,10 +104,9 @@ GaussianSimulationStrategy::GaussianSimulationStrategy() {
 @brief Constructor of the class.
 @param covariance_matrix The covariance matrix describing the gaussian state
 @param cutoff the Fock basis truncation.
-@param max_photons specifies the maximum number of photons that can be counted in the output samples.
 @return Returns with the instance of the class.
 */
-GaussianSimulationStrategy::GaussianSimulationStrategy( matrix &covariance_matrix, const size_t& cutoff, const size_t& max_photons ) {
+GaussianSimulationStrategy::GaussianSimulationStrategy( matrix &covariance_matrix, const size_t& cutoff ) {
 
 #ifdef __MPI__
     // Get the number of processes
@@ -126,7 +124,6 @@ GaussianSimulationStrategy::GaussianSimulationStrategy( matrix &covariance_matri
 
     state = GaussianState_Cov( covariance_matrix, qudratures );
     setCutoff( cutoff );
-    setMaxPhotons( max_photons );
 
 
 
@@ -142,10 +139,9 @@ GaussianSimulationStrategy::GaussianSimulationStrategy( matrix &covariance_matri
 @param covariance_matrix The covariance matrix describing the gaussian state
 @param displacement The mean (displacement) of the Gaussian state
 @param cutoff the Fock basis truncation.
-@param max_photons specifies the maximum number of photons that can be counted in the output samples.
 @return Returns with the instance of the class.
 */
-GaussianSimulationStrategy::GaussianSimulationStrategy( matrix &covariance_matrix, matrix& displacement, const size_t& cutoff, const size_t& max_photons ) {
+GaussianSimulationStrategy::GaussianSimulationStrategy( matrix &covariance_matrix, matrix& displacement, const size_t& cutoff ) {
 
 #ifdef __MPI__
     // Get the number of processes
@@ -167,7 +163,6 @@ GaussianSimulationStrategy::GaussianSimulationStrategy( matrix &covariance_matri
     state = GaussianState_Cov(covariance_matrix, displacement, qudratures);
 
     setCutoff( cutoff );
-    setMaxPhotons( max_photons );
 
     dim = covariance_matrix.rows;
     dim_over_2 = dim/2;
@@ -212,16 +207,6 @@ GaussianSimulationStrategy::setCutoff( const size_t& cutoff_in ) {
 
 }
 
-/**
-@brief Call to set the maximum number of photons that can be counted in the output samples.
-@param max_photons_in The maximum number of photons that can be counted in the output samples.
-*/
-void
-GaussianSimulationStrategy::setMaxPhotons( const size_t& max_photons_in ) {
-
-    max_photons = max_photons_in;
-
-}
 
 
 /**
@@ -360,9 +345,6 @@ exit(-1);
         current_output[mode_idx-1] = chosen_index;
         current_output.number_of_photons = output_sample.number_of_photons + chosen_index;
 
-        if (current_output.number_of_photons > max_photons) {
-            return PicState_int64(0);
-        }
 
         output_sample = current_output;
 

--- a/cpiquasso/sampling/simulation_strategies/source/GaussianSimulationStrategy.h
+++ b/cpiquasso/sampling/simulation_strategies/source/GaussianSimulationStrategy.h
@@ -32,8 +32,6 @@ protected:
 
     /// cutoff of the Fock basis truncation.
     size_t cutoff;
-    /// the maximum number of photons that can be counted in the output samples.
-    size_t max_photons;
     /// The dimension of the covariance matrix
     size_t dim;
     /// The number of the input modes stored by the covariance matrix
@@ -59,10 +57,9 @@ GaussianSimulationStrategy();
 @brief Constructor of the class. (The displacement is set to zero by this constructor)
 @param covariance_matrix_in The covariance matrix describing the gaussian state
 @param cutoff the Fock basis truncation.
-@param max_photons specifies the maximum number of photons that can be counted in the output samples.
 @return Returns with the instance of the class.
 */
-GaussianSimulationStrategy( matrix &covariance_matrix_in, const size_t& cutoff, const size_t& max_photons );
+GaussianSimulationStrategy( matrix &covariance_matrix_in, const size_t& cutoff );
 
 
 /**
@@ -70,10 +67,9 @@ GaussianSimulationStrategy( matrix &covariance_matrix_in, const size_t& cutoff, 
 @param covariance_matrix_in The covariance matrix describing the gaussian state
 @param displacement The mean (displacement) of the Gaussian state
 @param cutoff the Fock basis truncation.
-@param max_photons specifies the maximum number of photons that can be counted in the output samples.
 @return Returns with the instance of the class.
 */
-GaussianSimulationStrategy( matrix &covariance_matrix_in, matrix& displacement_in, const size_t& cutoff, const size_t& max_photons );
+GaussianSimulationStrategy( matrix &covariance_matrix_in, matrix& displacement_in, const size_t& cutoff );
 
 /**
 @brief Destructor of the class
@@ -93,11 +89,6 @@ void Update_covariance_matrix( matrix &covariance_matrix_in );
 */
 void setCutoff( const size_t& cutoff_in );
 
-/**
-@brief Call to set the maximum number of photons that can be counted in the output samples.
-@param max_photons_in The maximum number of photons that can be counted in the output samples.
-*/
-void setMaxPhotons( const size_t& max_photons_in );
 
 /**
 @brief Call to get samples from the gaussian state

--- a/cpiquasso/sampling/simulation_strategies/source/GaussianSimulationStrategyFast.cpp
+++ b/cpiquasso/sampling/simulation_strategies/source/GaussianSimulationStrategyFast.cpp
@@ -86,11 +86,10 @@ GaussianSimulationStrategyFast::GaussianSimulationStrategyFast() : GaussianSimul
 @brief Constructor of the class. (The displacement is set to zero by this constructor)
 @param covariance_matrix_in The covariance matrix describing the gaussian state
 @param cutoff the Fock basis truncation.
-@param max_photons specifies the maximum number of photons that can be counted in the output samples.
 @return Returns with the instance of the class.
 */
-GaussianSimulationStrategyFast::GaussianSimulationStrategyFast( matrix &covariance_matrix_in, const size_t& cutoff, const size_t& max_photons ) :
-    GaussianSimulationStrategy(covariance_matrix_in, cutoff, max_photons) {
+GaussianSimulationStrategyFast::GaussianSimulationStrategyFast( matrix &covariance_matrix_in, const size_t& cutoff ) :
+    GaussianSimulationStrategy(covariance_matrix_in, cutoff) {
 
 
 }
@@ -101,11 +100,10 @@ GaussianSimulationStrategyFast::GaussianSimulationStrategyFast( matrix &covarian
 @param covariance_matrix_in The covariance matrix describing the gaussian state
 @param displacement The mean (displacement) of the Gaussian state
 @param cutoff the Fock basis truncation.
-@param max_photons specifies the maximum number of photons that can be counted in the output samples.
 @return Returns with the instance of the class.
 */
-GaussianSimulationStrategyFast::GaussianSimulationStrategyFast( matrix &covariance_matrix_in, matrix& displacement_in, const size_t& cutoff, const size_t& max_photons ) :
-    GaussianSimulationStrategy(covariance_matrix_in, displacement_in, cutoff, max_photons) {
+GaussianSimulationStrategyFast::GaussianSimulationStrategyFast( matrix &covariance_matrix_in, matrix& displacement_in, const size_t& cutoff ) :
+    GaussianSimulationStrategy(covariance_matrix_in, displacement_in, cutoff ) {
 
 }
 

--- a/cpiquasso/sampling/simulation_strategies/source/GaussianSimulationStrategyFast.h
+++ b/cpiquasso/sampling/simulation_strategies/source/GaussianSimulationStrategyFast.h
@@ -37,10 +37,9 @@ GaussianSimulationStrategyFast();
 @brief Constructor of the class. (The displacement is set to zero by this constructor)
 @param covariance_matrix_in The covariance matrix describing the gaussian state
 @param cutoff the Fock basis truncation.
-@param max_photons specifies the maximum number of photons that can be counted in the output samples.
 @return Returns with the instance of the class.
 */
-GaussianSimulationStrategyFast( matrix &covariance_matrix_in, const size_t& cutoff, const size_t& max_photons );
+GaussianSimulationStrategyFast( matrix &covariance_matrix_in, const size_t& cutoff );
 
 
 /**
@@ -48,10 +47,9 @@ GaussianSimulationStrategyFast( matrix &covariance_matrix_in, const size_t& cuto
 @param covariance_matrix_in The covariance matrix describing the gaussian state
 @param displacement The mean (displacement) of the Gaussian state
 @param cutoff the Fock basis truncation.
-@param max_photons specifies the maximum number of photons that can be counted in the output samples.
 @return Returns with the instance of the class.
 */
-GaussianSimulationStrategyFast( matrix &covariance_matrix_in, matrix& displacement_in, const size_t& cutoff, const size_t& max_photons );
+GaussianSimulationStrategyFast( matrix &covariance_matrix_in, matrix& displacement_in, const size_t& cutoff );
 
 
 


### PR DESCRIPTION
Removing max_photons from GaussianSimulationStrategy and GaussianSimulationStrategyFast and their wrapper classes, respectively. The samples which contain more photons than expected, are listed as well.