### PR TITLE
fix(simulation_strategies): Inject seed from Python

### DIFF
--- a/cpiquasso/sampling/simulation_strategies/GaussianSimulationStrategyFast_wrapper.cpp
+++ b/cpiquasso/sampling/simulation_strategies/GaussianSimulationStrategyFast_wrapper.cpp
@@ -161,6 +161,11 @@ GaussianSimulationStrategyFast_wrapper_init(GaussianSimulationStrategyFast_wrapp
     // create instance of class ChinHuhPermanentCalculator
     self->simulation_strategy = create_ChinHuhPermanentCalculator( covariance_matrix_mtx, m_mtx, fock_cutoff );
 
+    PyObject* constants = PyImport_ImportModule("piquasso.api.constants");
+    PyObject* result = PyObject_CallMethod(constants, "get_seed", "");
+
+    self->simulation_strategy->seed(PyLong_AsUnsignedLongLong(result));
+
     return 0;
 }
 

--- a/cpiquasso/sampling/simulation_strategies/GeneralizedCliffordsSimulationStrategy_wrapper.cpp
+++ b/cpiquasso/sampling/simulation_strategies/GeneralizedCliffordsSimulationStrategy_wrapper.cpp
@@ -131,7 +131,14 @@ GeneralizedCliffordsSimulationStrategy_wrapper_init(GeneralizedCliffordsSimulati
     pic::matrix interferometer_matrix_mtx = numpy2matrix(self->interferometer_matrix);
 
     // create instance of class ChinHuhPermanentCalculator
-    self->simulation_strategy = cerate_ChinHuhPermanentCalculator( interferometer_matrix_mtx );
+    self->simulation_strategy = cerate_ChinHuhPermanentCalculator(
+        interferometer_matrix_mtx
+    );
+
+    PyObject* constants = PyImport_ImportModule("piquasso.api.constants");
+    PyObject* result = PyObject_CallMethod(constants, "get_seed", "");
+
+    self->simulation_strategy->seed(PyLong_AsUnsignedLongLong(result));
 
     return 0;
 }

--- a/cpiquasso/sampling/simulation_strategies/source/CGeneralizedCliffordsSimulationStrategy.cpp
+++ b/cpiquasso/sampling/simulation_strategies/source/CGeneralizedCliffordsSimulationStrategy.cpp
@@ -42,8 +42,7 @@ sum( PicState_int64 &vec) {
 */
 CGeneralizedCliffordsSimulationStrategy::CGeneralizedCliffordsSimulationStrategy() {
    // seed the random generator
-   srand ( time ( NULL));
-
+    seed(time(NULL));
 }
 
 
@@ -57,8 +56,7 @@ CGeneralizedCliffordsSimulationStrategy::CGeneralizedCliffordsSimulationStrategy
     Update_interferometer_matrix( interferometer_matrix_in );
 
     // seed the random generator
-    srand ( time ( NULL));
-
+    seed(time(NULL));
 }
 
 
@@ -66,6 +64,15 @@ CGeneralizedCliffordsSimulationStrategy::CGeneralizedCliffordsSimulationStrategy
 @brief Destructor of the class
 */
 CGeneralizedCliffordsSimulationStrategy::~CGeneralizedCliffordsSimulationStrategy() {
+}
+
+/**
+@brief Seeds the simulation with a specified value
+@param value The value to seed with
+*/
+void
+CGeneralizedCliffordsSimulationStrategy::seed(unsigned long long int value) {
+    srand(value);
 }
 
 /**

--- a/cpiquasso/sampling/simulation_strategies/source/CGeneralizedCliffordsSimulationStrategy.h
+++ b/cpiquasso/sampling/simulation_strategies/source/CGeneralizedCliffordsSimulationStrategy.h
@@ -58,6 +58,13 @@ CGeneralizedCliffordsSimulationStrategy( matrix &interferometer_matrix_in );
 */
 ~CGeneralizedCliffordsSimulationStrategy();
 
+
+/**
+@brief Seeds the simulation with a specified value
+@param value The value to seed with
+*/
+void seed(unsigned long long int value);
+
 /**
 @brief Call to update the memor address of the stored matrix iinterferometer_matrix
 @param interferometer_matrix_in The matrix describing the interferometer

--- a/cpiquasso/sampling/simulation_strategies/source/GaussianSimulationStrategy.cpp
+++ b/cpiquasso/sampling/simulation_strategies/source/GaussianSimulationStrategy.cpp
@@ -99,6 +99,15 @@ GaussianSimulationStrategy::GaussianSimulationStrategy() {
 
 }
 
+/**
+@brief Seeds the simulation with a specified value
+@param value The value to seed with
+*/
+void
+GaussianSimulationStrategy::seed(unsigned long long int value) {
+    srand(value);
+}
+
 
 /**
 @brief Constructor of the class.
@@ -130,7 +139,7 @@ GaussianSimulationStrategy::GaussianSimulationStrategy( matrix &covariance_matri
     dim = covariance_matrix.rows;
     dim_over_2 = dim/2;
 
-
+    seed(time(NULL));
 }
 
 
@@ -167,11 +176,7 @@ GaussianSimulationStrategy::GaussianSimulationStrategy( matrix &covariance_matri
     dim = covariance_matrix.rows;
     dim_over_2 = dim/2;
 
-    // seed the random generator
-    srand ( time ( NULL));
-
-
-
+    seed(time(NULL));
 }
 
 
@@ -215,11 +220,6 @@ GaussianSimulationStrategy::setCutoff( const size_t& cutoff_in ) {
 */
 std::vector<PicState_int64>
 GaussianSimulationStrategy::simulate( int samples_number ) {
-
-    // seed the random generator
-    srand ( time( NULL) );
-
-
     // preallocate the memory for the output states
     std::vector<PicState_int64> samples;
     samples.reserve(samples_number);

--- a/cpiquasso/sampling/simulation_strategies/source/GaussianSimulationStrategy.h
+++ b/cpiquasso/sampling/simulation_strategies/source/GaussianSimulationStrategy.h
@@ -91,6 +91,13 @@ void setCutoff( const size_t& cutoff_in );
 
 
 /**
+@brief Seeds the simulation with a specified value
+@param value The value to seed with
+*/
+void seed(unsigned long long int seed);
+
+
+/**
 @brief Call to get samples from the gaussian state
 @param samples_number The number of shots for which the output should be determined
 @return Returns with the samples of the gaussian state


### PR DESCRIPTION
The `GaussianSimulationStrategy` and
`CGeneralizedCliffordsSimulationStrategy` is seeded from the `*_wrapper`
classes after instantiation. The reseeding is removed from the
`simulate` methods, since from python this class is used as a singleton
anyway.