### PR TITLE
Fixing the creation of input matrices for recursive hafnian calculators

### DIFF
--- a/cpiquasso/sampling/simulation_strategies/source/GaussianSimulationStrategy.h
+++ b/cpiquasso/sampling/simulation_strategies/source/GaussianSimulationStrategy.h
@@ -109,14 +109,6 @@ protected:
 */
 PicState_int64 getSample();
 
-
-/**
-@brief Call to calculate the inverse of matrix Q defined by Eq (3) of Ref. arXiv 2010.15595
-@param state An instance of Gaussian state in the Fock representation. (If the Gaussian state is in quadrature representation, than it is transformed into Fock-space representation)
-@return Returns with the Hamilton matrix A.
-*/
-matrix calc_Qinv( GaussianState_Cov& state );
-
 /**
 @brief Call to calculate the inverse of matrix Q defined by Eq (3) of Ref. arXiv 2010.15595 and the determinant of Q.
 Since the determinant can be calculated by LU factorization, which is also necessary to calculate the inverse, we

--- a/cpiquasso/sampling/simulation_strategies/source/GaussianSimulationStrategyFast.cpp
+++ b/cpiquasso/sampling/simulation_strategies/source/GaussianSimulationStrategyFast.cpp
@@ -153,7 +153,6 @@ GaussianSimulationStrategyFast::calc_probability( matrix& Qinv, const double& Qd
             }
         }
 
-
         // calculate alpha * Qinv * conj(alpha)
         Complex16 inner_prod(0.0,0.0);
         for (size_t idx=0; idx<m.size(); idx++) {
@@ -235,7 +234,6 @@ else {
         // calculate gamma according to Eq (9) of arXiv 2010.15595v3 and set them into the diagonal of A_S
         diag_correction_of_A_S( A_S, Qinv, m, current_output );
 
-
         PowerTraceLoopHafnian hafnian_calculator = PowerTraceLoopHafnian(A_S);
         hafnian = hafnian_calculator.calculate();
 */
@@ -243,18 +241,17 @@ else {
 
         // prepare input matrix for recursive hafnian algorithm
         matrix mtx_permuted;
+        matrix diags_permuted;
         PicState_int64 repeated_column_pairs;
 
         // calculate gamma according to Eq (9) of arXiv 2010.15595v3
         matrix&& gamma = CalcGamma( Qinv, m, selected_modes );
 
-        ConstructMatrixForRecursiveLoopPowerTrace(A, gamma, current_output, mtx_permuted, repeated_column_pairs);
+        ConstructMatrixForRecursiveLoopPowerTrace(A, gamma, current_output, mtx_permuted, diags_permuted, repeated_column_pairs);
 
-
-        PowerTraceLoopHafnianRecursive hafnian_calculator_recursive = PowerTraceLoopHafnianRecursive(mtx_permuted, repeated_column_pairs);
+        PowerTraceLoopHafnianRecursive hafnian_calculator_recursive = PowerTraceLoopHafnianRecursive(mtx_permuted, diags_permuted, repeated_column_pairs);
         hafnian = hafnian_calculator_recursive.calculate();
         //Complex16 hafnian2 = hafnian_calculator_recursive.calculate();
-
 
 /*
 {
@@ -291,8 +288,6 @@ else {
 */
 matrix
 GaussianSimulationStrategyFast::CalcGamma( matrix& Qinv, matrix& m, PicState_int64& selected_modes ) {
-//std::cout << "GaussianSimulationStrategyFast::diag_correction_of_A " << A.rows << " " << Qinv.rows << " " << Qinv.cols << " " << m.size() << std::endl;
-//selected_modes.print_matrix();
 
     matrix gamma(Qinv.rows, 1);
     //memset(gamma.get_data(), 0, gamma.size()*sizeof(Complex16));
@@ -305,6 +300,7 @@ GaussianSimulationStrategyFast::CalcGamma( matrix& Qinv, matrix& m, PicState_int
             gamma[row_idx] = gamma[row_idx] + mult_a_bconj( Qinv[row_offset + col_idx], m[col_idx] );
         }
     }
+
 
     return gamma;
 

--- a/cpiquasso/sampling/simulation_strategies/source/RepeatedColumnPairs.h
+++ b/cpiquasso/sampling/simulation_strategies/source/RepeatedColumnPairs.h
@@ -136,9 +136,10 @@ void ConstructMatrixForRecursivePowerTrace(matrix &mtx, PicState_int64& modes, m
 @param mtx The input matrix for which the repeated matrix should be constructed.
 @param modes The mode occupancies for which the mode pairs are determined.
 @param mtx_out A matrix (not preallocated) to reference the constructed matrix.
+@param diags_out A matrix (not preallocated) to reference the constructed diagonal elements.
 @param repeated_column_pairs An array containing the repeating factors of the successive column pairs is returned by this reference.
 */
-void ConstructMatrixForRecursiveLoopPowerTrace(matrix &mtx, matrix& gamma, PicState_int64& modes, matrix &mtx_out, PicState_int64& repeated_column_pairs);
+void ConstructMatrixForRecursiveLoopPowerTrace(matrix &mtx, matrix& gamma, PicState_int64& modes, matrix &mtx_out, matrix &diags_out, PicState_int64& repeated_column_pairs);
 
 
 } //PIC

--- a/cpiquasso/sampling/source/PowerTraceHafnianRecursive.cpp
+++ b/cpiquasso/sampling/source/PowerTraceHafnianRecursive.cpp
@@ -209,7 +209,6 @@ PowerTraceHafnianRecursive_Tasks::calculate() {
 Complex16
 PowerTraceHafnianRecursive_Tasks::calculate(unsigned long long start_idx, unsigned long long step_idx, unsigned long long max_idx ) {
 
-
     if (mtx.rows == 0) {
         // the hafnian of an empty matrix is 1 by definition
         return Complex16(1,0);
@@ -324,7 +323,6 @@ PowerTraceHafnianRecursive_Tasks::calculate(unsigned long long start_idx, unsign
 */
 void
 PowerTraceHafnianRecursive_Tasks::IterateOverSelectedModes( const PicVector<char>& selected_modes, const PicState_int64& current_occupancy, size_t mode_to_iterate, tbb::combinable<ComplexM<long double>>& priv_addend, tbb::task_group &tg ) {
-
 
 
     // spawn iteration over the next mode if available
@@ -590,13 +588,8 @@ PowerTraceHafnianRecursive_Tasks::CreateAZ( const PicVector<char>& selected_mode
 
                 for (size_t filling_factor_col=1; filling_factor_col<=current_occupancy[mode_jdx]; filling_factor_col++) {
 
-                    if ( (row_idx == col_idx) || (mode_idx != mode_jdx) ) {
-
-                        A[row_offset_A_a + col_idx*2]   = mtx[row_offset_mtx_a + (selected_modes[mode_jdx]*2)];
-                        A[row_offset_A_aconj + col_idx*2+1] = mtx[row_offset_mtx_aconj + (selected_modes[mode_jdx]*2+1)];
-
-                    }
-
+                    A[row_offset_A_a + col_idx*2]   = mtx[row_offset_mtx_a + (selected_modes[mode_jdx]*2)];
+                    A[row_offset_A_aconj + col_idx*2+1] = mtx[row_offset_mtx_aconj + (selected_modes[mode_jdx]*2+1)];
                     A[row_offset_A_a + col_idx*2+1] = mtx[row_offset_mtx_a + (selected_modes[mode_jdx]*2+1)];
                     A[row_offset_A_aconj + col_idx*2]   = mtx[row_offset_mtx_aconj + (selected_modes[mode_jdx]*2)];
                     col_idx++;

--- a/cpiquasso/sampling/source/PowerTraceHafnianRecursive.h
+++ b/cpiquasso/sampling/source/PowerTraceHafnianRecursive.h
@@ -145,8 +145,7 @@ virtual Complex32 CalculatePartialHafnian( const PicVector<char>& selected_modes
 @param scale_factor_AZ The scale factor that has been used to scale the matrix elements of AZ =returned by reference)
 @return Returns with the constructed matrix \f$ A^Z \f$.
 */
-matrix
-CreateAZ( const PicVector<char>& selected_modes, const PicState_int64& current_occupancy, const size_t& total_num_of_occupancy, double &scale_factor_AZ );
+virtual matrix CreateAZ( const PicVector<char>& selected_modes, const PicState_int64& current_occupancy, const size_t& total_num_of_occupancy, double &scale_factor_AZ );
 
 
 

--- a/cpiquasso/sampling/source/PowerTraceLoopHafnianRecursive.h
+++ b/cpiquasso/sampling/source/PowerTraceLoopHafnianRecursive.h
@@ -22,6 +22,8 @@ class PowerTraceLoopHafnianRecursive : public PowerTraceLoopHafnian {
 
 
 protected:
+    /// The diagonal elements of the input matrix
+    matrix diag;
     /// An array describing the occupancy to be used to calculate the hafnian. The i-th mode is repeated occupancy[i] times.
     PicState_int64 occupancy;
 
@@ -36,6 +38,18 @@ The \f$ 2*i \f$-th and  \f$ (2*i+1) \f$-th rows and columns are repeated occupan
 @return Returns with the instance of the class.
 */
 PowerTraceLoopHafnianRecursive( matrix &mtx_in, PicState_int64& occupancy_in );
+
+
+/**
+@brief Constructor of the class.
+@param mtx_in A symmetric matrix. ( In GBS calculations the \f$ a_1, a_2, ... a_n, a_1^*, a_2^*, ... a_n^* \f$ ordered covariance matrix of the Gaussian state.)
+@param diag_elements_in
+@param occupancy_in An \f$ n \f$ long array describing the number of rows an columns to be repeated during the hafnian calculation.
+The \f$ 2*i \f$-th and  \f$ (2*i+1) \f$-th rows and columns are repeated occupancy[i] times.
+(The matrix mtx itself does not contain any repeated rows and column.)
+@return Returns with the instance of the class.
+*/
+PowerTraceLoopHafnianRecursive( matrix &mtx_in, matrix &diag_in, PicState_int64& occupancy_in );
 
 
 /**
@@ -63,6 +77,9 @@ purpose loop hafnian calculator. This algorithm accounts for the repeated occupa
 */
 class PowerTraceLoopHafnianRecursive_Tasks : public PowerTraceHafnianRecursive_Tasks {
 
+protected:
+    /// The diagonal elements of the input matrix
+    matrix diag;
 
 public:
 
@@ -75,6 +92,18 @@ The \f$ 2*i \f$-th and  \f$ (2*i+1) \f$-th rows and columns are repeated occupan
 @return Returns with the instance of the class.
 */
 PowerTraceLoopHafnianRecursive_Tasks( matrix &mtx_in, PicState_int64& occupancy_in );
+
+
+/**
+@brief Constructor of the class.
+@param mtx_in A symmetric matrix. ( In GBS calculations the \f$ a_1, a_2, ... a_n, a_1^*, a_2^*, ... a_n^* \f$ ordered covariance matrix of the Gaussian state.)
+@param diag_elements_in
+@param occupancy_in An \f$ n \f$ long array describing the number of rows an columns to be repeated during the hafnian calculation.
+The \f$ 2*i \f$-th and  \f$ (2*i+1) \f$-th rows and columns are repeated occupancy[i] times.
+(The matrix mtx itself does not contain any repeated rows and column.)
+@return Returns with the instance of the class.
+*/
+PowerTraceLoopHafnianRecursive_Tasks( matrix &mtx_in, matrix &diag_elements_in, PicState_int64& occupancy_in );
 
 
 /**
@@ -94,6 +123,15 @@ protected:
 Complex32 CalculatePartialHafnian( const PicVector<char>& selected_modes, const  PicState_int64& current_occupancy );
 
 
+/**
+@brief Call to construct matrix \f$ A^Z \f$ (see the text below Eq. (3.20) of arXiv 1805.12498) for the given modes and their occupancy
+@param selected_modes Selected modes over which the iterations are run
+@param current_occupancy Current occupancy of the selected modes for which the partial hafnian is calculated
+@param num_of_modes The number of modes (including degeneracies) that have been previously calculated. (it is the sum of values in current_occupancy)
+@param scale_factor_AZ The scale factor that has been used to scale the matrix elements of AZ =returned by reference)
+@return Returns with the constructed matrix \f$ A^Z \f$.
+*/
+matrix CreateAZ( const PicVector<char>& selected_modes, const PicState_int64& current_occupancy, const size_t& total_num_of_occupancy, double &scale_factor_AZ );
 
 /**
 @brief Call to scale the input matrix according to according to Eq (2.14) of in arXiv 1805.12498

--- a/ctests/hafnian_recursive_complex_matrix.cpp
+++ b/ctests/hafnian_recursive_complex_matrix.cpp
@@ -55,9 +55,7 @@ create_repeated_mtx( pic::matrix& A, pic::PicState_int64& filling_factors ) {
             // insert column elements
             for (size_t jdx=0; jdx<filling_factors.size(); jdx++) {
                 for (size_t col_repeat=0; col_repeat<filling_factors[jdx]; col_repeat++) {
-                    if ( (row_idx == col_idx) || (idx != jdx) ) {
-                        A_S[row_offset + col_idx] = A[row_offset_A + jdx];
-                    }
+                    A_S[row_offset + col_idx] = A[row_offset_A + jdx];
                     col_idx++;
                 }
             }
@@ -87,9 +85,7 @@ create_repeated_mtx( pic::matrix& A, pic::PicState_int64& filling_factors ) {
             // insert column elements
             for (size_t jdx=0; jdx<filling_factors.size(); jdx++) {
                 for (size_t col_repeat=0; col_repeat<filling_factors[jdx]; col_repeat++) {
-                    if ( (row_idx == col_idx) || (idx != jdx) ) {
-                        A_S[row_offset + col_idx + dim_A_S] = A[row_offset_A + jdx + dim_A];
-                    }
+                    A_S[row_offset + col_idx + dim_A_S] = A[row_offset_A + jdx + dim_A];
                     col_idx++;
                 }
 

--- a/ctests/loop_hafnian_recursive_complex_matrix.cpp
+++ b/ctests/loop_hafnian_recursive_complex_matrix.cpp
@@ -52,9 +52,7 @@ create_repeated_mtx( pic::matrix& A, pic::PicState_int64& filling_factors ) {
             // insert column elements
             for (size_t jdx=0; jdx<filling_factors.size(); jdx++) {
                 for (size_t col_repeat=0; col_repeat<filling_factors[jdx]; col_repeat++) {
-                    if ( (row_idx == col_idx) || (idx != jdx) ) {
-                        A_S[row_offset + col_idx] = A[row_offset_A + jdx];
-                    }
+                    A_S[row_offset + col_idx] = A[row_offset_A + jdx];
                     col_idx++;
                 }
             }
@@ -64,7 +62,6 @@ create_repeated_mtx( pic::matrix& A, pic::PicState_int64& filling_factors ) {
             for (size_t jdx=0; jdx<filling_factors.size(); jdx++) {
                 for (size_t col_repeat=0; col_repeat<filling_factors[jdx]; col_repeat++) {
                     A_S[row_offset + col_idx + dim_A_S] = A[row_offset_A + jdx + dim_A];
-
                     col_idx++;
                 }
 
@@ -85,9 +82,7 @@ create_repeated_mtx( pic::matrix& A, pic::PicState_int64& filling_factors ) {
             // insert column elements
             for (size_t jdx=0; jdx<filling_factors.size(); jdx++) {
                 for (size_t col_repeat=0; col_repeat<filling_factors[jdx]; col_repeat++) {
-                    if ( (row_idx == col_idx) || (idx != jdx) ) {
-                        A_S[row_offset + col_idx + dim_A_S] = A[row_offset_A + jdx + dim_A];
-                    }
+                    A_S[row_offset + col_idx + dim_A_S] = A[row_offset_A + jdx + dim_A];
                     col_idx++;
                 }
 
@@ -188,6 +183,7 @@ int main() {
     for (size_t idx=0; idx<filling_factors.size(); idx++) {
         filling_factors[idx] = 1;
     }
+
     filling_factors[0] = 2;
     filling_factors[1] = 0;
     filling_factors[2] = 1;


### PR DESCRIPTION
The creation of permuted matrices for recursive hafnian calculators in fast GBS was faulty.
Also the creation of repeated matrices A_S was faulty for ordinari hafnian calculators