### PR TITLE
Bugfix: Recursive torontonian caluclation for 2x2 matrices

### DIFF
--- a/cpiquasso/sampling/source/TorontonianRecursive.cpp
+++ b/cpiquasso/sampling/source/TorontonianRecursive.cpp
@@ -61,7 +61,7 @@ TorontonianRecursive::calculate(bool use_extended = true) {
 
     if (mtx.rows == 0) {
         // the hafnian of an empty matrix is 1 by definition
-        return 0.0;
+        return 1.0;
     }
 
 

--- a/cpiquasso/sampling/source/TorontonianRecursive.hpp
+++ b/cpiquasso/sampling/source/TorontonianRecursive.hpp
@@ -156,6 +156,11 @@ double calculate() {
         // the hafnian of an empty matrix is 1 by definition
         return 1.0;
     }
+    else if (mtx.rows == 2) {
+        complex_type determinant = mtx[0]*mtx[3] - mtx[1]*mtx[2];
+        long double partial_torontonian = 1.0/std::sqrt(determinant.real());
+        return (double)partial_torontonian - 1.0;
+    }
 
 #if BLAS==0 // undefined BLAS
     int NumThreads = omp_get_max_threads();


### PR DESCRIPTION
Modifying default value for torontonian and adding explicit code for calculating torontonian of a 2 by 2 matrix.