### PR TITLE
fix: Excluding _skbuild

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include pyproject.toml
 global-include *.h *h.in *.c *.cpp *.hpp CMakeLists.txt check_AVX.cmake README.md 
+prune _skbuild


### PR DESCRIPTION
The `_skbuild` folder needs to be excluded from the build process since
at multiple builds, the `_skbuild` folders are copied recursively.