### PR TITLE
refact(gaussian): Simplifying C extension class

### DIFF
--- a/piquassoboost/gaussian/source/CGaussianState.cpp
+++ b/piquassoboost/gaussian/source/CGaussianState.cpp
@@ -20,22 +20,6 @@ namespace pic {
 CGaussianState::CGaussianState() {}
 
 /**
-@brief Constructor of the class.
-@param C_in Input matrix defined by
-@param G_in Input matrix defined by
-@param m_in Input matrix defined by
-@return Returns with the instance of the class.
-*/
-CGaussianState::CGaussianState( matrix &C_in, matrix &G_in, matrix &m_in) {
-
-    Update( C_in, G_in, m_in);
-}
-
-
-
-
-
-/**
 @brief Applies the matrix T to the C and G.
 @param T The matrix of the transformation.
 @param modes The modes, on which the matrix should operate.

--- a/piquassoboost/gaussian/source/CGaussianState.h
+++ b/piquassoboost/gaussian/source/CGaussianState.h
@@ -30,16 +30,6 @@ public:
 */
 CGaussianState();
 
-
-/**
-@brief Constructor of the class.
-@param C_in Input matrix defined by
-@param G_in Input matrix defined by
-@param m_in Input matrix defined by
-@return Returns with the instance of the class.
-*/
-CGaussianState( matrix &C_in, matrix &G_in, matrix &m_in);
-
 /**
 @brief Call to update the memory addresses of the stored matrices
 @param C_in Input matrix defined by

--- a/piquassoboost/gaussian/state.py
+++ b/piquassoboost/gaussian/state.py
@@ -29,16 +29,8 @@ from piquassoboost.sampling.simulation_strategies import ThresholdBosonSampling
 
 class GaussianState(GaussianState_Wrapper, pq.GaussianState):
     def __init__(self, *, d):
-        self.d = d
-
-        vector_shape = (self.d, )
-        matrix_shape = vector_shape * 2
-
-        super().__init__(
-            m=np.zeros(vector_shape, dtype=complex),
-            G=np.zeros(matrix_shape, dtype=complex),
-            C=np.zeros(matrix_shape, dtype=complex),
-        )
+        self.create_wrapped_state()
+        super().__init__(d=d)
 
     def apply_passive(self, T, modes):
         self._m[modes, ] = T @ self._m[modes, ]
@@ -91,16 +83,3 @@ class GaussianState(GaussianState_Wrapper, pq.GaussianState):
             m=reduced_state.mean / np.sqrt(pq.api.constants.HBAR),
             fock_cutoff=cutoff,
         ).simulate(shots)
-
-def calculate_threshold_detection_probability(
-    state,
-    subspace_modes,
-    occupation_numbers,
-):
-    d = len(subspace_modes)
-
-    Q = (state.complex_covariance + np.identity(2 * d)) / 2
-
-    OS = (np.identity(2 * d, dtype=complex) - np.linalg.inv(Q)).conj()
-
-    OS_reduced = block_reduce(OS, reduce_on=occupation_numbers)


### PR DESCRIPTION
**Problem**

We strive to minimize boilerplate code. Specifically, we want to
push the existing logic from `piquassoboost.gaussian.state` to
`state_wrapper.cpp` C extension, which would reduce boilerplate for the
Gaussian backend. In the near future calling other algorithms would be
moved to the C extension, e.g. `ThresholdBosonSampling`.

**Partial solution**

In this patch, the `__init__` method of `GaussianState` is moved to its
C extension. The `create_wrapped_state` method has been created to
instantiate the wrapped `CGaussianState`. This wrapped class is
instantiated without arguments, since the matrices `C`, `G`, `m` do not
exist yet.

Since the non-empty constructor is not used anywhere with this
modification, it has been deleted in `CGaussianState`.

Finally, the `calculate_threshold_detection_probability` method has been
deleted from `state.py`, since it is not being used.