### PR TITLE
fix(setup.py): Freezing `piquasso` version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,8 @@ setup(
     install_requires=[
         "numpy>=1.19.4",
         (
-            "piquasso@git+ssh://git@github.com/"
-            "Budapest-Quantum-Computing-Group/piquasso.git"
+            "piquasso@git+ssh://git@github.com/Budapest-Quantum-Computing-Group/"
+            "piquasso.git@0.2.0#egg=piquasso"
         ),  # TODO: install a package instead!
     ],
     tests_require=["pytest"],


### PR DESCRIPTION
The `piquasso` dependency of `piquassoboost` is freezed to `0.2.0`.

References:
- https://stackoverflow.com/a/54794506