### PR TITLE
Connecting `PowerTraceLoopHafnian` to `GaussianState`

### DIFF
--- a/piquassoboost/sampling/source/PowerTraceLoopHafnian.cpp
+++ b/piquassoboost/sampling/source/PowerTraceLoopHafnian.cpp
@@ -53,9 +53,30 @@ PowerTraceLoopHafnian::PowerTraceLoopHafnian() : PowerTraceHafnian() {
 @return Returns with the instance of the class.
 */
 PowerTraceLoopHafnian::PowerTraceLoopHafnian( matrix &mtx_in ) {
+#ifdef DEBUG
     assert(isSymmetric(mtx_in));
+#endif
+   
+    
+    if (mtx_in.rows % 2 == 1){
+        matrix extended_matrix(mtx_in.rows + 1, mtx_in.cols + 1);
+        for (int row_idx = 0; row_idx < mtx_in.rows; row_idx++){
+            std::memcpy(
+                extended_matrix.get_data() + row_idx * extended_matrix.stride,
+                mtx_in.get_data() + row_idx * mtx_in.stride,
+                sizeof(Complex16) * mtx_in.cols
+            );
+            extended_matrix[row_idx * extended_matrix.stride + mtx_in.cols] = 
+                Complex16(0.0, 0.0);
+        }
+        Complex16 *row_last = extended_matrix.get_data() + mtx_in.rows * extended_matrix.stride;
+        std::fill(row_last, row_last + mtx_in.cols, Complex16(0.0, 0.0));
+        row_last[mtx_in.cols] = Complex16(1.0, 0.0);
 
-    Update_mtx( mtx_in );
+        Update_mtx( extended_matrix );
+    }else{
+        Update_mtx( mtx_in );
+    }
 
 }
 
@@ -341,7 +362,6 @@ PowerTraceLoopHafnian::Update_mtx( matrix &mtx_in) {
 
     // scale the input matrix according to according to Eq (2.14) of in arXiv 1805.12498
     ScaleMatrix();
-
 
 
 }

--- a/scripts
+++ b/scripts
@@ -1,0 +1,1 @@
+piquasso-module/scripts

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         "numpy>=1.19.4",
         (
             "piquasso@git+ssh://git@github.com/Budapest-Quantum-Computing-Group/"
-            "piquasso.git@0.2.0#egg=piquasso"
+            "piquasso.git@0.2.1#egg=piquasso"
         ),  # TODO: install a package instead!
     ],
     tests_require=["pytest"],


### PR DESCRIPTION
Adding extended matrix for PowerTraceLoopHafnian in case the matrix size is odd.
If the shape of the matrix is odd, the calculation is done on an extended matrix with a 0 padding with 1 at the corner.
    
The `PowerTraceLoopHafnian` is connected to the GBS calculation in
`GaussianState` in this patch.
    
A new symlink `scripts` has been created to enable testing the algorithm
with histograms an hypothesis tests.
    
The submodule and the dependency package version has been updated to
`0.2.1`.
