### PR TITLE
feat(permanents): python interface for Glynn repeated permanent calcu…

### DIFF
--- a/piquassoboost/sampling/CMakeLists.txt
+++ b/piquassoboost/sampling/CMakeLists.txt
@@ -20,16 +20,21 @@ add_library( Boson_Sampling_Utilities_wrapper MODULE
     ${EXT_DIR}/Boson_Sampling_Utilities_wrapper.cpp
     ${PROJECT_SOURCE_DIR}/piquassoboost/common/numpy_interface.cpp
 )
+add_library(permanent_calculators MODULE
+    ${EXT_DIR}/permanent_calculators_wrapper.cpp
+    ${PROJECT_SOURCE_DIR}/piquassoboost/common/numpy_interface.cpp
+)
 
 target_link_libraries(Boson_Sampling_Utilities_wrapper 
                           piquassoboost 
                           ${BLAS_LIBRARIES})
+target_link_libraries(permanent_calculators piquassoboost ${BLAS_LIBRARIES})
 
 python_extension_module(Boson_Sampling_Utilities_wrapper)
-
+python_extension_module(permanent_calculators)
 
 ADD_DEPENDENCIES (Boson_Sampling_Utilities_wrapper piquassoboost)
-
+ADD_DEPENDENCIES (permanent_calculators piquassoboost)
 
 
 # adding compile options
@@ -39,10 +44,23 @@ target_compile_options(Boson_Sampling_Utilities_wrapper PRIVATE
     "$<$<CONFIG:Release>:${CXX_FLAGS_RELEASE}>"
     "-DCPYTHON"
 )
+target_compile_options(permanent_calculators PRIVATE
+    ${CXX_FLAGS}
+    "$<$<CONFIG:Debug>:${CXX_FLAGS_DEBUG}>"
+    "$<$<CONFIG:Release>:${CXX_FLAGS_RELEASE}>"
+)
+
 
 
 
 target_include_directories(Boson_Sampling_Utilities_wrapper PUBLIC
+                            ${PROJECT_SOURCE_DIR}/piquassoboost/sampling/source/
+                            ${PROJECT_SOURCE_DIR}/piquassoboost/common/source/
+                            ${PROJECT_SOURCE_DIR}/piquassoboost/common/
+                            ${EXTRA_INCLUDES}
+                            ${PYTHON_INCLUDE_DIR}
+                            ${NUMPY_INC_DIR})
+target_include_directories(permanent_calculators PUBLIC
                             ${PROJECT_SOURCE_DIR}/piquassoboost/sampling/source/
                             ${PROJECT_SOURCE_DIR}/piquassoboost/common/source/
                             ${PROJECT_SOURCE_DIR}/piquassoboost/common/
@@ -56,8 +74,12 @@ set_target_properties( Boson_Sampling_Utilities_wrapper PROPERTIES
                         INSTALL_RPATH "$ORIGIN/.."
                         LIBRARY_OUTPUT_DIRECTORY ${EXT_DIR}
 )
-
+set_target_properties( permanent_calculators PROPERTIES
+                        INSTALL_RPATH "$ORIGIN/.."
+                        LIBRARY_OUTPUT_DIRECTORY ${EXT_DIR}
+)
 
 
 install(TARGETS Boson_Sampling_Utilities_wrapper LIBRARY DESTINATION piquassoboost/sampling)
-
+install(TARGETS permanent_calculators LIBRARY 
+         DESTINATION piquassoboost/gaussian)

--- a/piquassoboost/sampling/permanent_calculators_wrapper.cpp
+++ b/piquassoboost/sampling/permanent_calculators_wrapper.cpp
@@ -1,0 +1,131 @@
+/**
+ * Copyright 2021 Budapest Quantum Computing Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define PY_SSIZE_T_CLEAN
+
+#include <Python.h>
+#include <numpy/arrayobject.h>
+#include "numpy_interface.h"
+#include "GlynnPermanentCalculatorRepeated.h"
+
+
+/** Python interface method for calculating the permanent of a matrix based on 
+ *  pic::GlynnPermanentCalculatorRepeated
+ */
+static PyObject *
+permanent_CPU_repeated(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    // The tuple of expected keywords
+    static char *kwlist[] = {(char*)"matrix", (char*)"input_state", (char*)"output_state", NULL};
+
+
+    PyObject *matrix_arg = NULL;
+    PyObject *input_state_arg = NULL;
+    PyObject *output_state_arg = NULL;
+
+    PyObject *matrix_pyobj = NULL;
+    PyObject *input_state_pyobj = NULL;
+    PyObject *output_state_pyobj = NULL;
+
+    // parsing input arguments
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OOO", kwlist,
+                                     &matrix_arg, &input_state_arg, &output_state_arg))
+        return -1;
+
+    // convert python object array to numpy C API array
+    if ( matrix_arg == NULL ) return -1;
+    if ( input_state_arg == NULL ) return -1;
+    if ( output_state_arg == NULL ) return -1;
+
+    // establish memory contiguous arrays for C calculations
+    if ( PyArray_IS_C_CONTIGUOUS(matrix_arg) ) {
+        matrix_pyobj = matrix_arg;
+        Py_INCREF(matrix_pyobj);
+    }
+    else {
+        matrix_pyobj = PyArray_FROM_OTF(matrix_arg, NPY_COMPLEX128, NPY_ARRAY_IN_ARRAY);
+    }
+
+    if ( PyArray_IS_C_CONTIGUOUS(input_state_arg) ) {
+        input_state_pyobj = input_state_arg;
+        Py_INCREF(input_state_pyobj);
+    }
+    else {
+        input_state_pyobj = PyArray_FROM_OTF(input_state_arg, NPY_INT64, NPY_ARRAY_IN_ARRAY);
+    }
+
+    if ( PyArray_IS_C_CONTIGUOUS(output_state_arg) ) {
+        output_state_pyobj = output_state_arg;
+        Py_INCREF(output_state_pyobj);
+    }
+    else {
+        output_state_pyobj = PyArray_FROM_OTF(output_state_arg, NPY_INT64, NPY_ARRAY_IN_ARRAY);
+    }
+
+
+    // create PIC version of the parameters
+    pic::matrix matrix_cpp = numpy2matrix(matrix_pyobj);
+    pic::PicState_int64 input_state = numpy2PicState_int64(input_state_pyobj);
+    pic::PicState_int64 output_state = numpy2PicState_int64(output_state_pyobj);
+
+    pic::GlynnPermanentCalculatorRepeated calculator = pic::GlynnPermanentCalculatorRepeated();
+    
+
+    pic::Complex16 ret = calculator.calculate(matrix_cpp, input_state, output_state);
+
+    // release numpy arrays
+    Py_DECREF(matrix_pyobj);
+    Py_DECREF(input_state_pyobj);
+    Py_DECREF(output_state_pyobj);
+
+    return Py_BuildValue("D", &ret);
+}
+
+
+
+extern "C"
+{
+
+
+static PyMethodDef permanent_calculators_functions[] = {
+    {
+        "permanent_CPU_repeated",
+        (PyCFunction)(void(*)(void)) permanent_CPU_repeated,
+        METH_VARARGS | METH_KEYWORDS,
+        "Calculate the permanent of the parameter matrix."
+    },
+    {NULL, NULL, 0, NULL}
+};
+
+static struct PyModuleDef permanent_calculators_module = {
+    PyModuleDef_HEAD_INIT,
+    "permanent_calculators",
+    NULL,
+    -1,
+    permanent_calculators_functions
+};
+
+PyMODINIT_FUNC
+PyInit_permanent_calculators(void)
+{
+    import_array();
+    return PyModule_Create(&permanent_calculators_module);
+}
+
+
+
+
+} //extern C


### PR DESCRIPTION
…lation

The permanent is calculated based on the input and output states which mean the
multiplicity of the specific rows and columns (e.g. (1..1) and (1..1) mean the
classical permanent calculation). This means the sum of input and output states
has to be equal.

Added python function for calculating the permanents with input and output
states of a matrix. If there are higher than 1 inputs or outputs the calculator
optimizes the calculation based on them.