### PR TITLE
Fix NumPy error for correctly returned 0-length arrays (must avoid Py…

### DIFF
--- a/piquassoboost/common/numpy_interface.cpp
+++ b/piquassoboost/common/numpy_interface.cpp
@@ -57,6 +57,7 @@ PyObject* array_from_ptr(void * ptr, int dim, npy_intp* shape, int np_type) {
 
 
         // create numpy array
+        if (shape[0] == 0) return PyArray_SimpleNew(dim, shape, np_type);
         PyObject* arr = PyArray_SimpleNewFromData(dim, shape, np_type, ptr);
 
         // set memory keeper for the numpy array


### PR DESCRIPTION
…Array_SetBaseObject)