### PR TITLE
Ka templating permanent calculators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -395,7 +395,6 @@ list(APPEND piquassoboost_files
     ${PROJECT_SOURCE_DIR}/piquassoboost/gaussian/source/tasks_apply_to_C_and_G/insert_transformed_cols.cpp
     ${PROJECT_SOURCE_DIR}/piquassoboost/gaussian/source/tasks_apply_to_C_and_G/insert_transformed_rows.cpp
     ${PROJECT_SOURCE_DIR}/piquassoboost/sampling/source/CChinHuhPermanentCalculator.cpp
-    ${PROJECT_SOURCE_DIR}/piquassoboost/sampling/source/GlynnPermanentCalculator.cpp
     ${PROJECT_SOURCE_DIR}/piquassoboost/sampling/source/GlynnPermanentCalculatorRepeated.cpp
     ${PROJECT_SOURCE_DIR}/piquassoboost/sampling/source/BatchedPermanentCalculator.cpp
     ${PROJECT_SOURCE_DIR}/piquassoboost/sampling/source/TorontonianUtilities.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -395,7 +395,6 @@ list(APPEND piquassoboost_files
     ${PROJECT_SOURCE_DIR}/piquassoboost/gaussian/source/tasks_apply_to_C_and_G/insert_transformed_cols.cpp
     ${PROJECT_SOURCE_DIR}/piquassoboost/gaussian/source/tasks_apply_to_C_and_G/insert_transformed_rows.cpp
     ${PROJECT_SOURCE_DIR}/piquassoboost/sampling/source/CChinHuhPermanentCalculator.cpp
-    ${PROJECT_SOURCE_DIR}/piquassoboost/sampling/source/GlynnPermanentCalculatorRepeated.cpp
     ${PROJECT_SOURCE_DIR}/piquassoboost/sampling/source/BatchedPermanentCalculator.cpp
     ${PROJECT_SOURCE_DIR}/piquassoboost/sampling/source/TorontonianUtilities.cpp
     ${PROJECT_SOURCE_DIR}/piquassoboost/sampling/source/Torontonian.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -406,6 +406,7 @@ list(APPEND piquassoboost_files
     ${PROJECT_SOURCE_DIR}/piquassoboost/sampling/source/PowerTraceLoopHafnianRecursive.cpp
     ${PROJECT_SOURCE_DIR}/piquassoboost/sampling/source/BruteForceHafnian.cpp
     ${PROJECT_SOURCE_DIR}/piquassoboost/sampling/source/BruteForceLoopHafnian.cpp
+    ${PROJECT_SOURCE_DIR}/piquassoboost/sampling/source/GlynnPermanentCalculators_implementation.cpp
     ${PROJECT_SOURCE_DIR}/piquassoboost/sampling/simulation_strategies/source/CGeneralizedCliffordsSimulationStrategy.cpp
     ${PROJECT_SOURCE_DIR}/piquassoboost/sampling/simulation_strategies/source/CGeneralizedCliffordsBSimulationStrategy.cpp
     ${PROJECT_SOURCE_DIR}/piquassoboost/sampling/simulation_strategies/source/ThresholdBosonSampling.cpp

--- a/ctests/permanents_accuracy.cpp
+++ b/ctests/permanents_accuracy.cpp
@@ -1,8 +1,8 @@
 // The aim of this script is to ensure every implementation of permanent calculator give concise results.
 
 
-#include "GlynnPermanentCalculator.hpp"
-#include "GlynnPermanentCalculatorRepeated.hpp"
+#include "GlynnPermanentCalculator.h"
+#include "GlynnPermanentCalculatorRepeated.h"
 #include "CChinHuhPermanentCalculator.h"
 #include "matrix_helper.hpp"
 #include "matrix32.h"

--- a/ctests/permanents_accuracy.cpp
+++ b/ctests/permanents_accuracy.cpp
@@ -2,7 +2,7 @@
 
 
 #include "GlynnPermanentCalculator.hpp"
-#include "GlynnPermanentCalculatorRepeated.h"
+#include "GlynnPermanentCalculatorRepeated.hpp"
 #include "CChinHuhPermanentCalculator.h"
 #include "matrix_helper.hpp"
 #include "matrix32.h"
@@ -53,7 +53,7 @@ void testOfSameValuesForRandomMatrix(int matrix_dimension, int mul){
         rowMultiplicities[i] = mul;
         colMultiplicities[i] = mul;
     }
-    pic::GlynnPermanentCalculatorRepeated bbfgrec_calculator;
+    pic::GlynnPermanentCalculatorRepeatedLongDouble bbfgrec_calculator;
     auto bbfgrec_permanent = bbfgrec_calculator.calculate(matrix, rowMultiplicities, colMultiplicities);
     
     if (AreClose(bbfgrec_permanent, bbfg_permanent) && AreClose(bbfgrec_permanent, ch_permanent)){
@@ -124,7 +124,7 @@ int main() {
         rowMultiplicities[i] = mul;
         colMultiplicities[i] = mul;
     }
-    pic::GlynnPermanentCalculatorRepeated bbfgrec_calculator;
+    pic::GlynnPermanentCalculatorRepeatedLongDouble bbfgrec_calculator;
 
     tbb::tick_count t4 = tbb::tick_count::now();
     auto bbfgrec_permanent = bbfgrec_calculator.calculate(matrix, rowMultiplicities, colMultiplicities);

--- a/ctests/permanents_accuracy.cpp
+++ b/ctests/permanents_accuracy.cpp
@@ -1,7 +1,7 @@
 // The aim of this script is to ensure every implementation of permanent calculator give concise results.
 
 
-#include "GlynnPermanentCalculator.h"
+#include "GlynnPermanentCalculator.hpp"
 #include "GlynnPermanentCalculatorRepeated.h"
 #include "CChinHuhPermanentCalculator.h"
 #include "matrix_helper.hpp"
@@ -34,7 +34,7 @@ void testOfSameValuesForRandomMatrix(int matrix_dimension, int mul){
 
 
     // First just check if I can get any results from BBFG formula.
-    pic::GlynnPermanentCalculator bbfg_calculator;
+    pic::GlynnPermanentCalculatorLongDouble bbfg_calculator;
 
     auto bbfg_permanent = bbfg_calculator.calculate(matrixMultipled);
 
@@ -99,7 +99,7 @@ int main() {
 
 
     // First just check if I can get any results from BBFG formula.
-    pic::GlynnPermanentCalculator bbfg_calculator;
+    pic::GlynnPermanentCalculatorLongDouble bbfg_calculator;
 
     tbb::tick_count t0 = tbb::tick_count::now();
     auto bbfg_permanent = bbfg_calculator.calculate(matrixMultipled);

--- a/ctests/permanents_speed.cpp
+++ b/ctests/permanents_speed.cpp
@@ -1,8 +1,8 @@
 // The aim of this script is to compare runtimes of each implementation of permanent calculator.
 
 
-#include "GlynnPermanentCalculator.hpp"
-#include "GlynnPermanentCalculatorRepeated.hpp"
+#include "GlynnPermanentCalculator.h"
+#include "GlynnPermanentCalculatorRepeated.h"
 #include "CChinHuhPermanentCalculator.h"
 #include "CGeneralizedCliffordsSimulationStrategy.h"
 #include "matrix_helper.hpp"

--- a/ctests/permanents_speed.cpp
+++ b/ctests/permanents_speed.cpp
@@ -2,7 +2,7 @@
 
 
 #include "GlynnPermanentCalculator.hpp"
-#include "GlynnPermanentCalculatorRepeated.h"
+#include "GlynnPermanentCalculatorRepeated.hpp"
 #include "CChinHuhPermanentCalculator.h"
 #include "CGeneralizedCliffordsSimulationStrategy.h"
 #include "matrix_helper.hpp"
@@ -122,7 +122,7 @@ void testCase(std::vector<int> input, std::vector<int> output, int iterationNumb
         pic::matrix adaptedMatrix = adaptedMatricesForRecursiveGlynn[i];
         pic::PicState_int64 inState = inputState;
         pic::PicState_int64 outState = outputState;
-        pic::GlynnPermanentCalculatorRepeated bbfgrec_calculator;
+        pic::GlynnPermanentCalculatorRepeatedLongDouble bbfgrec_calculator;
 
         tbb::tick_count t0 = tbb::tick_count::now();
         auto bbfgrec_permanent = bbfgrec_calculator.calculate(adaptedMatrix, adaptedInputState, adaptedOutputState);

--- a/ctests/permanents_speed.cpp
+++ b/ctests/permanents_speed.cpp
@@ -1,7 +1,7 @@
 // The aim of this script is to compare runtimes of each implementation of permanent calculator.
 
 
-#include "GlynnPermanentCalculator.h"
+#include "GlynnPermanentCalculator.hpp"
 #include "GlynnPermanentCalculatorRepeated.h"
 #include "CChinHuhPermanentCalculator.h"
 #include "CGeneralizedCliffordsSimulationStrategy.h"
@@ -82,7 +82,7 @@ void testCase(std::vector<int> input, std::vector<int> output, int iterationNumb
     std::vector<pic::matrix> adaptedMatricesForNormalGlynn;
     for (int i = 0; i < iterationNumber; i++){
         adaptedMatricesForNormalGlynn.push_back(
-            pic::adaptInterferometerGlynnMultiplied(normalMatrices[i], inputState, outputState)
+            pic::adaptInterferometerGlynnMultiplied(normalMatrices[i], &inputState, &outputState)
         );
     }
 
@@ -107,7 +107,7 @@ void testCase(std::vector<int> input, std::vector<int> output, int iterationNumb
 
     for (int i = 0; i < iterationNumber; i++){
         pic::matrix& adaptedMatrix = adaptedMatricesForNormalGlynn[i];
-        pic::GlynnPermanentCalculator bbfg_calculator;
+        pic::GlynnPermanentCalculatorLongDouble bbfg_calculator;
 
         tbb::tick_count t0 = tbb::tick_count::now();
         auto bbfg_permanent = bbfg_calculator.calculate(adaptedMatrix);

--- a/performance_tests/test_permanent_calculators.py
+++ b/performance_tests/test_permanent_calculators.py
@@ -22,7 +22,7 @@ from thewalrus import perm as sf_perm
 from scipy.stats import unitary_group
 
 from piquassoboost.sampling.Boson_Sampling_Utilities import ChinHuhPermanentCalculator
-from piquassoboost.sampling.Boson_Sampling_Utilities import GlynnPermanent, GlynnRepeatedPermanentCalculator
+from piquassoboost.sampling.Boson_Sampling_Utilities import GlynnPermanent, GlynnRepeatedPermanentCalculator, GlynnPermanentDoubleCPU
 
 class TestPermanentCalculators:
     """bechmark tests for permanent calculator algorithms
@@ -30,7 +30,7 @@ class TestPermanentCalculators:
 
     def test_repeated_input(self):
         """Check input data handling in repeated Glynn calculator"""
-
+        
         dim = 20
         A = unitary_group.rvs(dim)
 
@@ -65,7 +65,7 @@ class TestPermanentCalculators:
 
     def test_value_repeated(self):
         """Check permanent value calculated by C++ Glynn permanent calculator"""
-
+        
         d = 15
         n = 10
 
@@ -126,7 +126,7 @@ class TestPermanentCalculators:
 
     def test_value_two_dimensional(self):
         """Check permanent value calculated by C++ Glynn permanent calculator"""
-
+        
         d = 15
         n = 10
 
@@ -193,3 +193,37 @@ class TestPermanentCalculators:
         print("time elapsed in PQ (Glynn)  :", pq_glynn_time)
         print("time elapsed in PQ (Chinhuh):", pq_chinhuh_time)
         
+
+
+
+    """performance test for measuring the calculation precision
+    """
+
+    def test_calculator_value(self):
+        """Check input data handling in Glynn calculators"""
+
+        dim = 2
+        A = unitary_group.rvs(dim)
+
+        print("Matrix input:")
+        print(A)
+        
+
+        value_from_double = 1.0 - 1.0j
+
+        # Glynn permanent calculator with double precision
+        permanent_calculator_Glynn_double_precision = GlynnPermanentDoubleCPU( A )
+        value_from_double = permanent_calculator_Glynn_double_precision.calculate()
+
+
+
+        value_from_long_double = 1.0 - 1.0j
+
+        # Glynn permanent calculator with long double precision
+        permanent_calculator_Glynn_long_double_precision = GlynnPermanent( A )
+        value_from_long_double = permanent_calculator_Glynn_long_double_precision.calculate()
+
+        print("value_from_double     :", value_from_double)
+        print("value_from_long_double:", value_from_long_double)
+
+

--- a/performance_tests/test_permanent_calculators.py
+++ b/performance_tests/test_permanent_calculators.py
@@ -21,8 +21,18 @@ from thewalrus import perm as sf_perm
 
 from scipy.stats import unitary_group
 
-from piquassoboost.sampling.Boson_Sampling_Utilities import ChinHuhPermanentCalculator
-from piquassoboost.sampling.Boson_Sampling_Utilities import GlynnPermanent, GlynnRepeatedPermanentCalculator, GlynnPermanentDoubleCPU
+from piquassoboost.sampling.Boson_Sampling_Utilities import (
+    ChinHuhPermanentCalculator,
+    GlynnPermanent,
+    GlynnRepeatedPermanentCalculator,
+    GlynnRepeatedPermanentCalculatorDouble,
+    GlynnPermanentDoubleCPU
+)
+
+from piquassoboost.sampling.permanent_calculators import (
+    permanent_CPU_repeated_double,
+    permanent_CPU_repeated_long_double
+)
 
 class TestPermanentCalculators:
     """bechmark tests for permanent calculator algorithms
@@ -30,7 +40,7 @@ class TestPermanentCalculators:
 
     def test_repeated_input(self):
         """Check input data handling in repeated Glynn calculator"""
-        
+
         dim = 20
         A = unitary_group.rvs(dim)
 
@@ -65,7 +75,7 @@ class TestPermanentCalculators:
 
     def test_value_repeated(self):
         """Check permanent value calculated by C++ Glynn permanent calculator"""
-        
+
         d = 15
         n = 10
 
@@ -126,7 +136,7 @@ class TestPermanentCalculators:
 
     def test_value_two_dimensional(self):
         """Check permanent value calculated by C++ Glynn permanent calculator"""
-        
+
         d = 15
         n = 10
 
@@ -196,13 +206,14 @@ class TestPermanentCalculators:
 
 
 
-    """performance test for measuring the calculation precision
+    """
+        performance test for measuring the calculation precision
     """
 
     def test_calculator_value(self):
         """Check input data handling in Glynn calculators"""
 
-        dim = 2
+        dim = 4
         A = unitary_group.rvs(dim)
 
         print("Matrix input:")
@@ -223,7 +234,25 @@ class TestPermanentCalculators:
         permanent_calculator_Glynn_long_double_precision = GlynnPermanent( A )
         value_from_long_double = permanent_calculator_Glynn_long_double_precision.calculate()
 
-        print("value_from_double     :", value_from_double)
-        print("value_from_long_double:", value_from_long_double)
 
 
+        # multiplicities of input/output states
+        input_state = np.ones(dim, np.int64)
+        output_state = np.ones(dim, np.int64)
+        # repeated Glynn permanent calculator with double precision
+        RepeatedGlynnDouble = GlynnRepeatedPermanentCalculatorDouble( A, input_state=input_state, output_state=output_state )
+        rep_value_from_double = RepeatedGlynnDouble.calculate()
+        rep_value_from_double2 = permanent_CPU_repeated_double( A, input_state, output_state )
+
+        # repeated Glynn permanent calculator with long double precision
+        RepeatedGlynnLongDouble = GlynnRepeatedPermanentCalculator( A, input_state=input_state, output_state=output_state )
+        rep_value_from_long_double = RepeatedGlynnLongDouble.calculate()
+        rep_value_from_long_double2 = permanent_CPU_repeated_long_double( A, input_state, output_state )
+
+
+        print("value_from_double          :", value_from_double)
+        print("value_from_long_double     :", value_from_long_double)
+        print("rep_value_from_double      :", rep_value_from_double)
+        print("rep_value_from_double2     :", rep_value_from_double2)
+        print("rep_value_from_long_double :", rep_value_from_long_double)
+        print("rep_value_from_long_double2:", rep_value_from_long_double2)

--- a/permanent_benchmark.py
+++ b/permanent_benchmark.py
@@ -1,6 +1,6 @@
 import numpy as np
 from thewalrus.libwalrus import perm_complex, perm_real, perm_BBFG_real, perm_BBFG_complex
-from piquassoboost.sampling.Boson_Sampling_Utilities import ChinHuhPermanentCalculator, GlynnPermanent, GlynnRepeatedPermanentCalculator, GlynnPermanentSingleDFE, GlynnPermanentDualDFE, GlynnPermanentInf
+from piquassoboost.sampling.Boson_Sampling_Utilities import ChinHuhPermanentCalculator, GlynnPermanent, GlynnPermanentDoubleCPU, GlynnRepeatedPermanentCalculator, GlynnPermanentSingleDFE, GlynnPermanentDualDFE, GlynnPermanentInf, GlynnRepeatedPermanentCalculatorDouble
 import piquasso as pq
 import random
 from scipy.stats import unitary_group
@@ -111,6 +111,23 @@ for idx in range(iter_loops):
         time_Glynn_Cpp_repeated = time_loc
 
 
+GlynnRepeatedPermanentCalculatorDouble
+
+# Glynn repeated permanent calculator
+permanent_Glynn_calculator_repeated = GlynnRepeatedPermanentCalculatorDouble( Arep, input_state=input_state, output_state=output_state )
+time_Glynn_Cpp_repeated_double = 1000000000
+for idx in range(iter_loops):
+    start = time.time()   
+
+    permanent_Glynn_Cpp_repeated_double = permanent_Glynn_calculator_repeated.calculate()
+
+    time_loc = time.time() - start
+    start = time.time()   
+       
+    if time_Glynn_Cpp_repeated_double > time_loc:
+        time_Glynn_Cpp_repeated_double = time_loc
+
+
 # Glynn permanent calculator
 permanent_Glynn_calculator = GlynnPermanent( Arep )
 time_Glynn_Cpp = 1000000000
@@ -126,12 +143,30 @@ for idx in range(iter_loops):
         time_Glynn_Cpp = time_loc
 
 
+
+# Glynn permanent calculator double
+permanent_Glynn_calculator = GlynnPermanentDoubleCPU( Arep )
+time_Glynn_Cpp_double = 1000000000
+for idx in range(iter_loops):
+    start = time.time()   
+
+    permanent_Glynn_Cpp_double = permanent_Glynn_calculator.calculate()
+
+    time_loc = time.time() - start
+    start = time.time()   
+       
+    if time_Glynn_Cpp_double > time_loc:
+        time_Glynn_Cpp_double = time_loc
+
+
 print(' ')
 print( permanent_walrus_quad_Ryser )
 print( permanent_walrus_quad_BBFG )
 print( permanent_ChinHuh_Cpp )
 print( permanent_Glynn_Cpp_repeated )
+print( permanent_Glynn_Cpp_repeated_double )
 print( permanent_Glynn_Cpp )
+print( permanent_Glynn_Cpp_double )
 
 # Glynn DFE permanent calculator
 permanent_Glynn_calculator = GlynnPermanentSingleDFE( Arep )
@@ -193,7 +228,9 @@ print('Time elapsed with walrus: ' + str(time_walrus))
 print('Time elapsed with walrus BBFG : ' + str(time_walrus_BBFG))
 print('Time elapsed with piquasso Chin-Huh: ' + str(time_Cpp))
 print('Time elapsed with piquasso Glynn: ' + str(time_Glynn_Cpp))
+print('Time elapsed with piquasso Glynn_double: ' + str(time_Glynn_Cpp_double))
 print('Time elapsed with piquasso Glynn repeated: ' + str(time_Glynn_Cpp_repeated))
+print('Time elapsed with piquasso Glynn repeated double: ' + str(time_Glynn_Cpp_repeated_double))
 print('Time elapsed with DFE Glynn: ' + str(time_Glynn_DFE))
 print('Time elapsed with dual DFE Glynn: ' + str(time_Glynn_dual_DFE))
 if (dim<=24):

--- a/piquassoboost/common/source/common_functionalities.cpp
+++ b/piquassoboost/common/source/common_functionalities.cpp
@@ -103,13 +103,14 @@ sum( const PicState_int64& vec) {
 
 
 /**
-@brief Call to calculate the Binomial Coefficient C(n, k)
+@brief Call to calculate the Binomial Coefficient C(n, k) templated version
 @param n The integer n
 @param k The integer k
 @return Returns with the Binomial Coefficient C(n, k).
 */
-int binomialCoeff(int n, int k) {
-   int C[k+1];
+template <typename int_type>
+int_type binomialCoeffTemplated(int n, int k) {
+   int_type C[k+1];
    memset(C, 0, sizeof(C));
    C[0] = 1;
    for (int i = 1; i <= n; i++) {
@@ -117,9 +118,17 @@ int binomialCoeff(int n, int k) {
          C[j] = C[j] + C[j-1];
    }
    return C[k];
-
 }
 
+
+inline int binomialCoeff(int n, int k){
+    return binomialCoeffTemplated<int>(n, k);
+}
+
+
+inline int64_t binomialCoeffInt64(int n, int k){
+    return binomialCoeffTemplated<int64_t>(n, k);
+}
 
 
 /**

--- a/piquassoboost/common/source/common_functionalities.cpp
+++ b/piquassoboost/common/source/common_functionalities.cpp
@@ -121,12 +121,12 @@ int_type binomialCoeffTemplated(int n, int k) {
 }
 
 
-inline int binomialCoeff(int n, int k){
+int binomialCoeff(int n, int k){
     return binomialCoeffTemplated<int>(n, k);
 }
 
 
-inline int64_t binomialCoeffInt64(int n, int k){
+int64_t binomialCoeffInt64(int n, int k){
     return binomialCoeffTemplated<int64_t>(n, k);
 }
 

--- a/piquassoboost/common/source/common_functionalities.h
+++ b/piquassoboost/common/source/common_functionalities.h
@@ -73,6 +73,15 @@ int binomialCoeff(int n, int k);
 
 
 /**
+@brief Call to calculate the Binomial Coefficient C(n, k) in int64_t
+@param n The integer n
+@param k The integer k
+@return Returns with the Binomial Coefficient C(n, k).
+*/
+int64_t binomialCoeffInt64(int n, int k);
+
+
+/**
 @brief Function which checks whether the given matrix is symmetric or not.
 @param mtx_in The given matrix.
 @param tolerance The tolerance value for being 2 different values equal.

--- a/piquassoboost/sampling/Boson_Sampling_Utilities.py
+++ b/piquassoboost/sampling/Boson_Sampling_Utilities.py
@@ -92,6 +92,14 @@ class ChinHuhPermanentCalculator(RepeatedPermanentCalculator):
 
 class GlynnRepeatedPermanentCalculator(RepeatedPermanentCalculator):
     def __init__(self, matrix, input_state, output_state):
+        """
+            This class is designed to calculate the permanent of
+            matrix using Glynn's algorithm
+            (Balasubramanian-Bax-Franklin-Glynn (BBFG) formula)
+            with long double precision and multipled rows or columns
+
+            1 shall be equal to GlynnRep
+        """
         super(GlynnRepeatedPermanentCalculator, self).__init__(1, matrix, input_state, output_state)
         pass
 
@@ -137,6 +145,21 @@ class GlynnRepeatedMultiDualDFEPermanentCalculator(RepeatedPermanentCalculator):
     def __init__(self, matrix, input_state, output_state):
         super(GlynnRepeatedMultiDualDFEPermanentCalculator, self).__init__(5, matrix, input_state, output_state)
         pass
+
+
+class GlynnRepeatedPermanentCalculatorDouble(RepeatedPermanentCalculator):
+    def __init__(self, matrix, input_state, output_state):
+        """
+            This class is designed to calculate the permanent of
+            matrix using Glynn's algorithm
+            (Balasubramanian-Bax-Franklin-Glynn (BBFG) formula)
+            with double precision and multipled rows or columns
+
+            5 shall be equal to GlynnRepCPUDouble
+        """
+        super(GlynnRepeatedPermanentCalculatorDouble, self).__init__(5, matrix, input_state, output_state)
+        pass
+
 
 
 

--- a/piquassoboost/sampling/Boson_Sampling_Utilities.py
+++ b/piquassoboost/sampling/Boson_Sampling_Utilities.py
@@ -202,6 +202,19 @@ class GlynnPermanentDualDFE(GlynnPermanentCalculator_wrapper):
         pass
 
        
+class GlynnPermanentDoubleCPU(GlynnPermanentCalculator_wrapper):
+    """
+        This class is designed to calculate the permanent of matrix using Glynn's algorithm (Balasubramanian-Bax-Franklin-Glynn (BBFG) formula) with double precision
+    """
+    
+
+    def __init__(self, matrix):
+
+        # call the constructor of the wrapper class
+        # 6 shall mean macro GlynnDoubleCPU
+        super(GlynnPermanentDoubleCPU, self).__init__(matrix, 6)
+        pass
+
 
 class PowerTraceHafnian(PowerTraceHafnian_wrapper):
     """

--- a/piquassoboost/sampling/Boson_Sampling_Utilities.py
+++ b/piquassoboost/sampling/Boson_Sampling_Utilities.py
@@ -147,6 +147,8 @@ class GlynnRepeatedMultiDualDFEPermanentCalculator(RepeatedPermanentCalculator):
         pass
 
 
+
+
 class GlynnRepeatedPermanentCalculatorDouble(RepeatedPermanentCalculator):
     def __init__(self, matrix, input_state, output_state):
         """
@@ -157,7 +159,7 @@ class GlynnRepeatedPermanentCalculatorDouble(RepeatedPermanentCalculator):
 
             5 shall be equal to GlynnRepCPUDouble
         """
-        super(GlynnRepeatedPermanentCalculatorDouble, self).__init__(5, matrix, input_state, output_state)
+        super(GlynnRepeatedPermanentCalculatorDouble, self).__init__(6, matrix, input_state, output_state)
         pass
 
 

--- a/piquassoboost/sampling/CMakeLists.txt
+++ b/piquassoboost/sampling/CMakeLists.txt
@@ -48,6 +48,7 @@ target_compile_options(permanent_calculators PRIVATE
     ${CXX_FLAGS}
     "$<$<CONFIG:Debug>:${CXX_FLAGS_DEBUG}>"
     "$<$<CONFIG:Release>:${CXX_FLAGS_RELEASE}>"
+    "-DCPYTHON"
 )
 
 

--- a/piquassoboost/sampling/CMakeLists.txt
+++ b/piquassoboost/sampling/CMakeLists.txt
@@ -82,4 +82,4 @@ set_target_properties( permanent_calculators PROPERTIES
 
 install(TARGETS Boson_Sampling_Utilities_wrapper LIBRARY DESTINATION piquassoboost/sampling)
 install(TARGETS permanent_calculators LIBRARY 
-         DESTINATION piquassoboost/gaussian)
+         DESTINATION piquassoboost/sampling)

--- a/piquassoboost/sampling/ChinHuhPermanentCalculator_Wrapper.hpp
+++ b/piquassoboost/sampling/ChinHuhPermanentCalculator_Wrapper.hpp
@@ -22,7 +22,7 @@
 #include <numpy/arrayobject.h>
 #include "structmember.h"
 #include "CChinHuhPermanentCalculator.h"
-#include "GlynnPermanentCalculatorRepeated.hpp"
+#include "GlynnPermanentCalculatorRepeated.h"
 
 #ifdef __DFE__
 #include "GlynnPermanentCalculatorDFE.h"

--- a/piquassoboost/sampling/ChinHuhPermanentCalculator_Wrapper.hpp
+++ b/piquassoboost/sampling/ChinHuhPermanentCalculator_Wrapper.hpp
@@ -38,7 +38,7 @@
 #define GlynnRepDualDFE 3
 #define GlynnRepMultiSingleDFE 4
 #define GlynnRepMultiDualDFE 5
-#define GlynnRepCPUDouble 5
+#define GlynnRepCPUDouble 6
 
 
 

--- a/piquassoboost/sampling/GlynnPermanentCalculator_Wrapper.hpp
+++ b/piquassoboost/sampling/GlynnPermanentCalculator_Wrapper.hpp
@@ -5,7 +5,7 @@
 #include <Python.h>
 #include <numpy/arrayobject.h>
 #include "structmember.h"
-#include "GlynnPermanentCalculator.hpp"
+#include "GlynnPermanentCalculator.h"
 
 #ifdef __MPFR__
 #include "GlynnPermanentCalculatorInf.h"

--- a/piquassoboost/sampling/permanent_calculators_wrapper.cpp
+++ b/piquassoboost/sampling/permanent_calculators_wrapper.cpp
@@ -19,14 +19,14 @@
 #include <Python.h>
 #include <numpy/arrayobject.h>
 #include "numpy_interface.h"
-#include "GlynnPermanentCalculatorRepeated.h"
+#include "GlynnPermanentCalculatorRepeated.hpp"
 
 
 /** Python interface method for calculating the permanent of a matrix based on 
- *  pic::GlynnPermanentCalculatorRepeated
+ *  pic::GlynnPermanentCalculatorRepeatedLongDouble
  */
 static PyObject *
-permanent_CPU_repeated(PyObject *self, PyObject *args, PyObject *kwds)
+permanent_CPU_repeated_long_double(PyObject *self, PyObject *args, PyObject *kwds)
 {
     // The tuple of expected keywords
     static char *kwlist[] = {(char*)"matrix", (char*)"input_state", (char*)"output_state", NULL};
@@ -81,8 +81,81 @@ permanent_CPU_repeated(PyObject *self, PyObject *args, PyObject *kwds)
     pic::PicState_int64 input_state = numpy2PicState_int64(input_state_pyobj);
     pic::PicState_int64 output_state = numpy2PicState_int64(output_state_pyobj);
 
-    pic::GlynnPermanentCalculatorRepeated calculator = pic::GlynnPermanentCalculatorRepeated();
-    
+    pic::GlynnPermanentCalculatorRepeatedLongDouble calculator = pic::GlynnPermanentCalculatorRepeatedLongDouble();
+
+
+    pic::Complex16 ret = calculator.calculate(matrix_cpp, input_state, output_state);
+
+    // release numpy arrays
+    Py_DECREF(matrix_pyobj);
+    Py_DECREF(input_state_pyobj);
+    Py_DECREF(output_state_pyobj);
+
+    return Py_BuildValue("D", &ret);
+}
+
+
+/** Python interface method for calculating the permanent of a matrix based on
+ *  pic::GlynnPermanentCalculatorRepeatedDouble
+ */
+static PyObject *
+permanent_CPU_repeated_double(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    // The tuple of expected keywords
+    static char *kwlist[] = {(char*)"matrix", (char*)"input_state", (char*)"output_state", NULL};
+
+
+    PyObject *matrix_arg = NULL;
+    PyObject *input_state_arg = NULL;
+    PyObject *output_state_arg = NULL;
+
+    PyObject *matrix_pyobj = NULL;
+    PyObject *input_state_pyobj = NULL;
+    PyObject *output_state_pyobj = NULL;
+
+    // parsing input arguments
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OOO", kwlist,
+                                     &matrix_arg, &input_state_arg, &output_state_arg))
+        return -1;
+
+    // convert python object array to numpy C API array
+    if ( matrix_arg == NULL ) return -1;
+    if ( input_state_arg == NULL ) return -1;
+    if ( output_state_arg == NULL ) return -1;
+
+    // establish memory contiguous arrays for C calculations
+    if ( PyArray_IS_C_CONTIGUOUS(matrix_arg) ) {
+        matrix_pyobj = matrix_arg;
+        Py_INCREF(matrix_pyobj);
+    }
+    else {
+        matrix_pyobj = PyArray_FROM_OTF(matrix_arg, NPY_COMPLEX128, NPY_ARRAY_IN_ARRAY);
+    }
+
+    if ( PyArray_IS_C_CONTIGUOUS(input_state_arg) ) {
+        input_state_pyobj = input_state_arg;
+        Py_INCREF(input_state_pyobj);
+    }
+    else {
+        input_state_pyobj = PyArray_FROM_OTF(input_state_arg, NPY_INT64, NPY_ARRAY_IN_ARRAY);
+    }
+
+    if ( PyArray_IS_C_CONTIGUOUS(output_state_arg) ) {
+        output_state_pyobj = output_state_arg;
+        Py_INCREF(output_state_pyobj);
+    }
+    else {
+        output_state_pyobj = PyArray_FROM_OTF(output_state_arg, NPY_INT64, NPY_ARRAY_IN_ARRAY);
+    }
+
+
+    // create PIC version of the parameters
+    pic::matrix matrix_cpp = numpy2matrix(matrix_pyobj);
+    pic::PicState_int64 input_state = numpy2PicState_int64(input_state_pyobj);
+    pic::PicState_int64 output_state = numpy2PicState_int64(output_state_pyobj);
+
+    pic::GlynnPermanentCalculatorRepeatedDouble calculator = pic::GlynnPermanentCalculatorRepeatedDouble();
+
 
     pic::Complex16 ret = calculator.calculate(matrix_cpp, input_state, output_state);
 
@@ -102,10 +175,16 @@ extern "C"
 
 static PyMethodDef permanent_calculators_functions[] = {
     {
-        "permanent_CPU_repeated",
-        (PyCFunction)(void(*)(void)) permanent_CPU_repeated,
+        "permanent_CPU_repeated_double",
+        (PyCFunction)(void(*)(void)) permanent_CPU_repeated_double,
         METH_VARARGS | METH_KEYWORDS,
-        "Calculate the permanent of the parameter matrix."
+        "Calculate the permanent of the parameter matrix with double precision."
+    },
+    {
+        "permanent_CPU_repeated_long_double",
+        (PyCFunction)(void(*)(void)) permanent_CPU_repeated_long_double,
+        METH_VARARGS | METH_KEYWORDS,
+        "Calculate the permanent of the parameter matrix with long double precision."
     },
     {NULL, NULL, 0, NULL}
 };

--- a/piquassoboost/sampling/permanent_calculators_wrapper.cpp
+++ b/piquassoboost/sampling/permanent_calculators_wrapper.cpp
@@ -19,7 +19,7 @@
 #include <Python.h>
 #include <numpy/arrayobject.h>
 #include "numpy_interface.h"
-#include "GlynnPermanentCalculatorRepeated.hpp"
+#include "GlynnPermanentCalculatorRepeated.h"
 
 
 /** Python interface method for calculating the permanent of a matrix based on 

--- a/piquassoboost/sampling/simulation_strategies/source/CGeneralizedCliffordsBSimulationStrategy.cpp
+++ b/piquassoboost/sampling/simulation_strategies/source/CGeneralizedCliffordsBSimulationStrategy.cpp
@@ -17,8 +17,7 @@
 #include <iostream>
 #include "CGeneralizedCliffordsBSimulationStrategy.h"
 #include "CChinHuhPermanentCalculator.h"
-#include "GlynnPermanentCalculator.h"
-#include "GlynnPermanentCalculatorRepeated.h"
+#include "GlynnPermanentCalculatorRepeated.hpp"
 #ifdef __DFE__
 #include "GlynnPermanentCalculatorDFE.h"
 #include "GlynnPermanentCalculatorRepeatedDFE.h"
@@ -363,7 +362,7 @@ CGeneralizedCliffordsBSimulationStrategy::compute_pmf( PicState_int64& sample ) 
 #endif
 
 
-        GlynnPermanentCalculatorRepeated permanentCalculator;
+        GlynnPermanentCalculatorRepeatedLongDouble permanentCalculator;
 
         tbb::parallel_for( (size_t)0, colIndices.size(), (size_t)1, [&](size_t idx) {
         //for (size_t idx=0; idx<colIndices.size(); idx++) {
@@ -487,7 +486,7 @@ CGeneralizedCliffordsBSimulationStrategy::compute_pmf( PicState_int64& sample ) 
         PicState_int64&& output_state = sample.copy();
         output_state[mdx]++;
 
-        GlynnPermanentCalculatorRepeated permanentCalculator;
+        GlynnPermanentCalculatorRepeatedLongDouble permanentCalculator;
 
         matrix&& modifiedInterferometerMatrix = adaptInterferometer( interferometer_matrix, current_input, output_state );
         PicState_int64 adapted_input_state = current_input.filter(filterNonZero);

--- a/piquassoboost/sampling/simulation_strategies/source/CGeneralizedCliffordsBSimulationStrategy.cpp
+++ b/piquassoboost/sampling/simulation_strategies/source/CGeneralizedCliffordsBSimulationStrategy.cpp
@@ -17,7 +17,7 @@
 #include <iostream>
 #include "CGeneralizedCliffordsBSimulationStrategy.h"
 #include "CChinHuhPermanentCalculator.h"
-#include "GlynnPermanentCalculatorRepeated.hpp"
+#include "GlynnPermanentCalculatorRepeated.h"
 #ifdef __DFE__
 #include "GlynnPermanentCalculatorDFE.h"
 #include "GlynnPermanentCalculatorRepeatedDFE.h"

--- a/piquassoboost/sampling/simulation_strategies/source/CGeneralizedCliffordsSimulationStrategy.cpp
+++ b/piquassoboost/sampling/simulation_strategies/source/CGeneralizedCliffordsSimulationStrategy.cpp
@@ -19,7 +19,7 @@
 #include "CChinHuhPermanentCalculator.h"
 #include "GlynnPermanentCalculator.h"
 #include "GlynnPermanentCalculatorDFE.h"
-#include "GlynnPermanentCalculatorRepeated.h"
+#include "GlynnPermanentCalculatorRepeated.hpp"
 #include "GlynnPermanentCalculatorRepeatedDFE.h"
 #include "CChinHuhPermanentCalculator.h"
 #include "common_functionalities.h"
@@ -607,7 +607,7 @@ calculate_outputs_probability( matrix &interferometer_mtx, PicState_int64 &input
     PicState_int64 adapted_output_state = output_state.filter(filterNonZero);
     
         
-    GlynnPermanentCalculatorRepeated permanentCalculatorRecursive;
+    GlynnPermanentCalculatorRepeatedLongDouble permanentCalculatorRecursive;
     permanent = permanentCalculatorRecursive.calculate( modifiedInterferometerMatrix, adapted_input_state, adapted_output_state );
 
     double probability = permanent.real()*permanent.real() + permanent.imag()*permanent.imag();

--- a/piquassoboost/sampling/simulation_strategies/source/CGeneralizedCliffordsSimulationStrategy.cpp
+++ b/piquassoboost/sampling/simulation_strategies/source/CGeneralizedCliffordsSimulationStrategy.cpp
@@ -19,7 +19,7 @@
 #include "CChinHuhPermanentCalculator.h"
 #include "GlynnPermanentCalculator.h"
 #include "GlynnPermanentCalculatorDFE.h"
-#include "GlynnPermanentCalculatorRepeated.hpp"
+#include "GlynnPermanentCalculatorRepeated.h"
 #include "GlynnPermanentCalculatorRepeatedDFE.h"
 #include "CChinHuhPermanentCalculator.h"
 #include "common_functionalities.h"

--- a/piquassoboost/sampling/source/BatchedPermanentCalculator.cpp
+++ b/piquassoboost/sampling/source/BatchedPermanentCalculator.cpp
@@ -3,7 +3,7 @@
 #include <tbb/scalable_allocator.h>
 #include "tbb/tbb.h"
 #include "common_functionalities.h"
-#include "GlynnPermanentCalculator.h"
+#include "GlynnPermanentCalculator.hpp"
 #include "GlynnPermanentCalculatorRepeated.h"
 #ifdef __DFE__
 #include "GlynnPermanentCalculatorDFE.h"
@@ -182,7 +182,7 @@ matrix BatchednPermanentCalculator::calculate(int lib) {
                     matrix ret_batched(ret.get_data()+start_index, 1, matrices->size());
 
                     if (matrices->begin()->rows < 4) { //compute with other method
-                        GlynnPermanentCalculator gpc;
+                        GlynnPermanentCalculatorLongDouble gpc;
                         for (size_t i = 0; i < matrices->size(); i++) {
                             ret_batched[i] = gpc.calculate((*matrices)[i]);
                         }

--- a/piquassoboost/sampling/source/BatchedPermanentCalculator.cpp
+++ b/piquassoboost/sampling/source/BatchedPermanentCalculator.cpp
@@ -3,8 +3,8 @@
 #include <tbb/scalable_allocator.h>
 #include "tbb/tbb.h"
 #include "common_functionalities.h"
-#include "GlynnPermanentCalculator.hpp"
-#include "GlynnPermanentCalculatorRepeated.hpp"
+#include "GlynnPermanentCalculator.h"
+#include "GlynnPermanentCalculatorRepeated.h"
 #ifdef __DFE__
 #include "GlynnPermanentCalculatorDFE.h"
 #endif

--- a/piquassoboost/sampling/source/BatchedPermanentCalculator.cpp
+++ b/piquassoboost/sampling/source/BatchedPermanentCalculator.cpp
@@ -4,7 +4,7 @@
 #include "tbb/tbb.h"
 #include "common_functionalities.h"
 #include "GlynnPermanentCalculator.hpp"
-#include "GlynnPermanentCalculatorRepeated.h"
+#include "GlynnPermanentCalculatorRepeated.hpp"
 #ifdef __DFE__
 #include "GlynnPermanentCalculatorDFE.h"
 #endif
@@ -103,7 +103,7 @@ matrix BatchednPermanentCalculator::calculate(int lib) {
     if ( lib == GlynnRep ) {
 
         //GlynnPermanentCalculator permanentCalculator;
-        GlynnPermanentCalculatorRepeated permanentCalculator;
+        GlynnPermanentCalculatorRepeatedLongDouble permanentCalculator;
 
         // define function to filter out nonzero elements
         std::function<bool(int64_t)> filterNonZero = [](int64_t elem) { 

--- a/piquassoboost/sampling/source/GlynnPermanentCalculator.h
+++ b/piquassoboost/sampling/source/GlynnPermanentCalculator.h
@@ -6,7 +6,11 @@
 #include "PicState.h"
 #include <vector>
 #include "PicVector.hpp"
+
+// avoid tbb usage at python interface
+#ifndef CPYTHON
 #include <tbb/tbb.h>
+#endif
 
 
 namespace pic {
@@ -51,8 +55,8 @@ Complex16 calculate(matrix &mtx);
 }; //GlynnPermanentCalculator
 
 
-
-
+// avoid tbb usage at python interface
+#ifndef CPYTHON
 
 
 /**
@@ -99,6 +103,9 @@ void IterateOverDeltas( matrix_type& colSum, int sign, int index_min );
 
 
 }; // partial permanent_Task
+
+#endif // CPYTHON
+
 
 
 /** alias for glynn permanent calculator with long double precision

--- a/piquassoboost/sampling/source/GlynnPermanentCalculator.h
+++ b/piquassoboost/sampling/source/GlynnPermanentCalculator.h
@@ -6,10 +6,7 @@
 #include "PicState.h"
 #include <vector>
 #include "PicVector.hpp"
-
-#ifndef CPYTHON
 #include <tbb/tbb.h>
-#endif
 
 
 namespace pic {
@@ -24,8 +21,13 @@ void print_state( Container state );
 
 
 /**
-@brief Interface class representing a Glynn permanent calculator
-*/
+ * @brief Interface class representing a Glynn permanent calculator
+ * 
+ * Specifying template parameters can adjust precision of the calculation (double or long double precision)
+ * @tparam matrix_type matrix with given precision inside calculation
+ * @tparam precision_type scalar precision inside calculation (double or long double)
+ */
+template<typename matrix_type, typename precision_type>
 class GlynnPermanentCalculator {
 
 public:
@@ -52,21 +54,23 @@ Complex16 calculate(matrix &mtx);
 
 
 
-// relieve Python extension from TBB functionalities
-#ifndef CPYTHON
-
 
 /**
-@brief Class to calculate a partial permanent via Glynn's formula scaling with n*2^n. (Does not use gray coding, but does the calculation is similar but scalable fashion) 
-*/
+ * @brief Class to calculate a partial permanent via Glynn's formula scaling with n*2^n. (Does not use gray coding, but does the calculation is similar but scalable fashion)
+ * 
+ * Specifying template parameters can adjust precision of the calculation (double or long double precision)
+ * @tparam matrix_type matrix with given precision inside calculation
+ * @tparam precision_type scalar precision inside calculation (double or long double)
+ */
+template<typename matrix_type, typename precision_type>
 class GlynnPermanentCalculatorTask {
 
 public:
 
-    /// 2*mtx used in the recursive calls (The storing of thos matrix spare many repeating multiplications)
-    matrix32 mtx2;
+    /// 2*mtx used in the recursive calls (The storing of this matrix spare many repeating multiplications)
+    matrix_type mtx2;
     /// thread local storage for partial permanents
-    tbb::combinable<ComplexM<long double>> priv_addend;
+    tbb::combinable<ComplexM<precision_type>> priv_addend;
 
 public:
 
@@ -86,21 +90,24 @@ Complex16 calculate(matrix &mtx);
 
 
 /**
-@brief Method to span parallel tasks via iterative function calls. (new task is spanned by altering one element in the vector of deltas)
-@param colSum The sum of \f$ \delta_j a_{ij} \f$ in Eq. (S2) of arXiv:1606.05836
-@param sign The current product \f$ \prod\delta_i $\f
-@param index_min \f$ \delta_j a_{ij} $\f with \f$ 0<i<index_min $\f are kept contstant, while the signs of \f$ \delta_i \f$  with \f$ i>=idx_min $\f are changed.
-*/
-void IterateOverDeltas( matrix32& colSum, int sign, int index_min );
+ * @brief Method to span parallel tasks via iterative function calls. (new task is spanned by altering one element in the vector of deltas)
+ * @param colSum The sum of \f$ \delta_j a_{ij} \f$ in Eq. (S2) of arXiv:1606.05836
+ * @param sign The current product \f$ \prod\delta_i $\f
+ * @param index_min \f$ \delta_j a_{ij} $\f with \f$ 0<i<index_min $\f are kept contstant, while the signs of \f$ \delta_i \f$  with \f$ i>=idx_min $\f are changed.
+ */
+void IterateOverDeltas( matrix_type& colSum, int sign, int index_min );
 
 
 }; // partial permanent_Task
 
 
-#endif // CPYTHON
+/** alias for glynn permanent calculator with long double precision
+ */
+using GlynnPermanentCalculatorLongDouble = GlynnPermanentCalculator<pic::matrix32, long double>;
 
-
-
+/** alias for glynn permanent calculator with double precision
+ */
+using GlynnPermanentCalculatorDouble = GlynnPermanentCalculator<pic::matrix, double>;
 
 } // PIC
 

--- a/piquassoboost/sampling/source/GlynnPermanentCalculator.hpp
+++ b/piquassoboost/sampling/source/GlynnPermanentCalculator.hpp
@@ -1,3 +1,22 @@
+/**
+ * Copyright 2022 Budapest Quantum Computing Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef GLYNN_PERMANENT_CALCULATOR_HPP
+#define GLYNN_PERMANENT_CALCULATOR_HPP
+
 #include <iostream>
 #include "GlynnPermanentCalculator.h"
 #include <tbb/scalable_allocator.h>
@@ -189,3 +208,5 @@ GlynnPermanentCalculatorTask<matrix_type, precision_type>::IterateOverDeltas( ma
 
 
 } // PIC
+
+#endif // GLYNN_PERMANENT_CALCULATOR_HPP

--- a/piquassoboost/sampling/source/GlynnPermanentCalculator.hpp
+++ b/piquassoboost/sampling/source/GlynnPermanentCalculator.hpp
@@ -32,9 +32,6 @@ GlynnPermanentCalculator<matrix_type, precision_type>::calculate(matrix &mtx) {
     if (mtx.rows >= mtx.cols + 2)
         return Complex16(0.0, 0.0);
 
-    std::cout << "matrix:"<<std::endl;
-    mtx.print_matrix();
-
     GlynnPermanentCalculatorTask<matrix_type, precision_type> calculator;
     return calculator.calculate( mtx );
 }
@@ -111,8 +108,6 @@ GlynnPermanentCalculatorTask<matrix_type, precision_type>::calculate(matrix &mtx
     });
 
     permanent = permanent / (precision_type)power_of_2( (unsigned long long) (mtx.rows-1) );
-
-  
 
 
     return Complex16(permanent.real(), permanent.imag());

--- a/piquassoboost/sampling/source/GlynnPermanentCalculator.hpp
+++ b/piquassoboost/sampling/source/GlynnPermanentCalculator.hpp
@@ -15,7 +15,8 @@ namespace pic {
 @brief Default constructor of the class.
 @return Returns with the instance of the class.
 */
-GlynnPermanentCalculator::GlynnPermanentCalculator() {}
+template<typename matrix_type, typename precision_type>
+GlynnPermanentCalculator<matrix_type, precision_type>::GlynnPermanentCalculator() {}
 
 
 /**
@@ -23,14 +24,18 @@ GlynnPermanentCalculator::GlynnPermanentCalculator() {}
 @param mtx Unitary describing a quantum circuit
 @return Returns with the calculated permanent
 */
+template<typename matrix_type, typename precision_type>
 Complex16
-GlynnPermanentCalculator::calculate(matrix &mtx) {
+GlynnPermanentCalculator<matrix_type, precision_type>::calculate(matrix &mtx) {
     if (mtx.rows == 0 || mtx.cols == 0)
         return Complex16(1.0, 0.0);
     if (mtx.rows >= mtx.cols + 2)
         return Complex16(0.0, 0.0);
 
-    GlynnPermanentCalculatorTask calculator;
+    std::cout << "matrix:"<<std::endl;
+    mtx.print_matrix();
+
+    GlynnPermanentCalculatorTask<matrix_type, precision_type> calculator;
     return calculator.calculate( mtx );
 }
 
@@ -40,21 +45,23 @@ GlynnPermanentCalculator::calculate(matrix &mtx) {
 @brief Default constructor of the class.
 @return Returns with the instance of the class.
 */
-GlynnPermanentCalculatorTask::GlynnPermanentCalculatorTask() {}
+template<typename matrix_type, typename precision_type>
+GlynnPermanentCalculatorTask<matrix_type, precision_type>::GlynnPermanentCalculatorTask() {}
 
 /**
 @brief Call to calculate the permanent via Glynn formula. scales with n*2^n
 @param mtx Unitary describing a quantum circuit
 @return Returns with the calculated permanent
 */
+template<typename matrix_type, typename precision_type>
 Complex16
-GlynnPermanentCalculatorTask::calculate(matrix &mtx) {
+GlynnPermanentCalculatorTask<matrix_type, precision_type>::calculate(matrix &mtx) {
 
     Complex16* mtx_data = mtx.get_data();
     
     // calculate and store 2*mtx being used later in the recursive calls
-    mtx2 = matrix32( mtx.rows, mtx.cols);
-    Complex32* mtx2_data = mtx2.get_data();
+    mtx2 = matrix_type( mtx.rows, mtx.cols);
+    Complex_base<precision_type>* mtx2_data = mtx2.get_data();
 
     tbb::parallel_for( tbb::blocked_range<size_t>(0, mtx.rows), [&](tbb::blocked_range<size_t> r) {
         for (size_t row_idx=r.begin(); row_idx<r.end(); ++row_idx){
@@ -70,9 +77,9 @@ GlynnPermanentCalculatorTask::calculate(matrix &mtx) {
 
 
     // calulate the initial sum of the columns
-    matrix32 colSum( mtx.cols, 1);
-    Complex32* colSum_data = colSum.get_data();
-    memset( colSum_data, 0.0, colSum.size()*sizeof(Complex32));
+    matrix_type colSum( mtx.cols, 1);
+    Complex_base<precision_type>* colSum_data = colSum.get_data();
+    memset( colSum_data, 0.0, colSum.size()*sizeof(Complex_base<precision_type>));
 
 
 
@@ -89,7 +96,7 @@ GlynnPermanentCalculatorTask::calculate(matrix &mtx) {
     });
 
     // thread local storage for partial permanent
-    priv_addend = tbb::combinable<ComplexM<long double>> {[](){return ComplexM<long double>();}};
+    priv_addend = tbb::combinable<ComplexM<precision_type>> {[](){return ComplexM<precision_type>();}};
 
 
     // start the iterations over vectors of deltas
@@ -97,13 +104,13 @@ GlynnPermanentCalculatorTask::calculate(matrix &mtx) {
 
 
     // sum up partial permanents
-    Complex32 permanent( 0.0, 0.0 );
+    Complex_base<precision_type> permanent( 0.0, 0.0 );
 
-    priv_addend.combine_each([&](ComplexM<long double> &a) {
+    priv_addend.combine_each([&](ComplexM<precision_type> &a) {
         permanent = permanent + a.get();
     });
 
-    permanent = permanent / (long double)power_of_2( (unsigned long long) (mtx.rows-1) );
+    permanent = permanent / (precision_type)power_of_2( (unsigned long long) (mtx.rows-1) );
 
   
 
@@ -121,19 +128,20 @@ GlynnPermanentCalculatorTask::calculate(matrix &mtx) {
 @param index_min \f$ \delta_j a_{ij} $\f with \f$ 0<i<index_min $\f are kept constant, while the signs of \f$ \delta_i \f$  with \f$ i>=idx_min $\f are changed.
 @param sign The current product \f$ \prod\delta_i $\f
 */
+template<typename matrix_type, typename precision_type>
 void 
-GlynnPermanentCalculatorTask::IterateOverDeltas( matrix32& colSum, int sign, int index_min ) {
+GlynnPermanentCalculatorTask<matrix_type, precision_type>::IterateOverDeltas( matrix_type& colSum, int sign, int index_min ) {
 
-    Complex32* colSum_data = colSum.get_data();
+    Complex_base<precision_type>* colSum_data = colSum.get_data();
 
     // Calculate the partial permanent
-    Complex32 colSumProd(1.0,0.0);
+    Complex_base<precision_type> colSumProd(1.0,0.0);
     for (int idx=0; idx<colSum.rows; idx++) {
         colSumProd = colSumProd * colSum_data[idx];
     }
 
     // add partial permanent to the local value
-    ComplexM<long double> &permanent_priv = priv_addend.local();
+    ComplexM<precision_type> &permanent_priv = this->priv_addend.local();
     permanent_priv += sign*colSumProd;
 
 
@@ -141,10 +149,10 @@ GlynnPermanentCalculatorTask::IterateOverDeltas( matrix32& colSum, int sign, int
         for (int idx=r.begin(); idx<r.end(); ++idx){
 
             // create an altered vector from the current delta
-            matrix32 colSum_new = colSum.copy();
+            matrix_type colSum_new = colSum.copy();
 
-            Complex32* mtx2_data = mtx2.get_data();
-            Complex32* colSum_new_data = colSum_new.get_data();
+            Complex_base<precision_type>* mtx2_data = mtx2.get_data();
+            Complex_base<precision_type>* colSum_new_data = colSum_new.get_data();
 
             size_t row_offset = idx*mtx2.stride;
 

--- a/piquassoboost/sampling/source/GlynnPermanentCalculatorDFE.cpp
+++ b/piquassoboost/sampling/source/GlynnPermanentCalculatorDFE.cpp
@@ -1,5 +1,5 @@
 #include "GlynnPermanentCalculatorDFE.h"
-#include "GlynnPermanentCalculator.hpp"
+#include "GlynnPermanentCalculator.h"
 
 #ifndef CPYTHON
 #include <tbb/tbb.h>

--- a/piquassoboost/sampling/source/GlynnPermanentCalculatorDFE.cpp
+++ b/piquassoboost/sampling/source/GlynnPermanentCalculatorDFE.cpp
@@ -1,5 +1,5 @@
 #include "GlynnPermanentCalculatorDFE.h"
-#include "GlynnPermanentCalculator.h"
+#include "GlynnPermanentCalculator.hpp"
 
 #ifndef CPYTHON
 #include <tbb/tbb.h>
@@ -347,7 +347,7 @@ GlynnPermanentCalculatorBatch_DFE(std::vector<matrix>& matrices, matrix& perm, i
 
     if (!((!useFloat && calcPermanentGlynnDFE) || (useFloat && calcPermanentGlynnDFEF)) ||
         matrices.begin()->rows < 1+dfe_basekernpow2) { //compute with other method
-      GlynnPermanentCalculator gpc;
+      GlynnPermanentCalculatorLongDouble gpc;
       for (size_t i = 0; i < matrices.size(); i++) {
           perm[i] = gpc.calculate(matrices[i]);
       }
@@ -392,7 +392,7 @@ GlynnPermanentCalculator_DFE(matrix& matrix_mtx, Complex16& perm, int useDual, i
 
     if (!((!useFloat && calcPermanentGlynnDFE) || (useFloat && calcPermanentGlynnDFEF)) ||
         matrix_mtx.rows < 1+dfe_basekernpow2 || matrix_mtx.cols == 0 || matrix_mtx.rows >= matrix_mtx.cols + 2) { //compute with other method
-      GlynnPermanentCalculator gpc;
+      GlynnPermanentCalculatorLongDouble gpc;
       perm = gpc.calculate(matrix_mtx);
       unlock_lib();
       dec_dfe_lib_count();

--- a/piquassoboost/sampling/source/GlynnPermanentCalculatorRepeated.h
+++ b/piquassoboost/sampling/source/GlynnPermanentCalculatorRepeated.h
@@ -127,7 +127,7 @@ void IterateOverDeltas(
     matrix_type& colSum,
     int sign,
     size_t index_min,
-    int currentMultiplicity
+    int64_t currentMultiplicity
 );
 
 

--- a/piquassoboost/sampling/source/GlynnPermanentCalculatorRepeated.h
+++ b/piquassoboost/sampling/source/GlynnPermanentCalculatorRepeated.h
@@ -7,10 +7,7 @@
 #include "PicState.h"
 #include <vector>
 #include "PicVector.hpp"
-
-#ifndef CPYTHON
 #include <tbb/tbb.h>
-#endif
 
 
 namespace pic {
@@ -27,6 +24,7 @@ void print_state( Container state );
 /**
 @brief Interface class representing a Glynn permanent calculator
 */
+template <typename matrix_type, typename precision_type>
 class GlynnPermanentCalculatorRepeated {
 
 protected:
@@ -61,16 +59,11 @@ Complex16 calculate(
 
 
 
-
-
-// relieve Python extension from TBB functionalities
-#ifndef CPYTHON
-
-
 /**
 @brief Class to calculate a partial permanent via Glynn's formula scaling with n*2^n.
 (Does not use gray coding, but does the calculation is similar but scalable fashion) 
 */
+template <typename matrix_type, typename precision_type>
 class GlynnPermanentCalculatorRepeatedTask {
 
 public:
@@ -79,9 +72,9 @@ public:
     matrix mtx;
     /// 2*mtx used in the recursive calls (The storing of thos matrix
     /// spare many repeating multiplications)
-    matrix32 mtx2;
+    matrix_type mtx2;
     /// thread local storage for partial permanents
-    tbb::combinable<ComplexM<long double>> priv_addend;
+    tbb::combinable<ComplexM<precision_type>> priv_addend;
 
     /// numbers describing the row multiplicity
     PicState_int& row_multiplicities;
@@ -125,7 +118,7 @@ Complex16 calculate();
 @param currentMultiplicity multiplicity of the current delta vector
 */
 void IterateOverDeltas(
-    matrix32& colSum,
+    matrix_type& colSum,
     int sign,
     size_t index_min,
     int currentMultiplicity
@@ -135,9 +128,15 @@ void IterateOverDeltas(
 }; // partial permanent_Task
 
 
-#endif // CPYTHON
+
+/** alias for glynn repeated permanent calculator with double precision
+ */
+using GlynnPermanentCalculatorRepeatedDouble = GlynnPermanentCalculatorRepeated<pic::matrix, double>;
 
 
+/** alias for glynn repeated permanent calculator with long double precision
+ */
+using GlynnPermanentCalculatorRepeatedLongDouble = GlynnPermanentCalculatorRepeated<pic::matrix32, long double>;
 
 
 } // PIC

--- a/piquassoboost/sampling/source/GlynnPermanentCalculatorRepeated.h
+++ b/piquassoboost/sampling/source/GlynnPermanentCalculatorRepeated.h
@@ -7,7 +7,11 @@
 #include "PicState.h"
 #include <vector>
 #include "PicVector.hpp"
+
+// avoid tbb usage at python interface
+#ifndef CPYTHON
 #include <tbb/tbb.h>
+#endif
 
 
 namespace pic {
@@ -58,6 +62,8 @@ Complex16 calculate(
 }; //GlynnPermanentCalculatorRepeated
 
 
+// avoid tbb usage at python interface
+#ifndef CPYTHON
 
 /**
 @brief Class to calculate a partial permanent via Glynn's formula scaling with n*2^n.
@@ -127,6 +133,7 @@ void IterateOverDeltas(
 
 }; // partial permanent_Task
 
+#endif // CPYTHON
 
 
 /** alias for glynn repeated permanent calculator with double precision

--- a/piquassoboost/sampling/source/GlynnPermanentCalculatorRepeated.hpp
+++ b/piquassoboost/sampling/source/GlynnPermanentCalculatorRepeated.hpp
@@ -186,7 +186,7 @@ GlynnPermanentCalculatorRepeatedTask<matrix_type, precision_type>::IterateOverDe
     matrix_type& colSum,
     int sign,
     size_t index_min,
-    int currentMultiplicity
+    int64_t currentMultiplicity
 ) {
     Complex_base<precision_type>* colSum_data = colSum.get_data();
 
@@ -225,7 +225,7 @@ GlynnPermanentCalculatorRepeatedTask<matrix_type, precision_type>::IterateOverDe
                     colSum_new, 
                     localSign,
                     idx+1,
-                    currentMultiplicity*binomialCoeff(deltaLimits[idx], indexOfMultiplicity)
+                    currentMultiplicity*binomialCoeffInt64(deltaLimits[idx], indexOfMultiplicity)
                 );
             }
         }

--- a/piquassoboost/sampling/source/GlynnPermanentCalculatorRepeated.hpp
+++ b/piquassoboost/sampling/source/GlynnPermanentCalculatorRepeated.hpp
@@ -1,3 +1,22 @@
+/**
+ * Copyright 2022 Budapest Quantum Computing Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef GLYNN_PERMANENT_CALCULATOR_REPEATED_HPP
+#define GLYNN_PERMANENT_CALCULATOR_REPEATED_HPP
+
+
 #include <iostream>
 #include "GlynnPermanentCalculatorRepeated.h"
 #include <tbb/scalable_allocator.h>
@@ -243,3 +262,6 @@ GlynnPermanentCalculatorRepeatedTask<matrix_type, precision_type>::IterateOverDe
 
 
 } // PIC
+
+
+#endif // GLYNN_PERMANENT_CALCULATOR_REPEATED_HPP

--- a/piquassoboost/sampling/source/GlynnPermanentCalculatorRepeatedDFE.cpp
+++ b/piquassoboost/sampling/source/GlynnPermanentCalculatorRepeatedDFE.cpp
@@ -1,5 +1,5 @@
 #include "GlynnPermanentCalculatorRepeatedDFE.h"
-#include "GlynnPermanentCalculatorRepeated.hpp"
+#include "GlynnPermanentCalculatorRepeated.h"
 #include "BatchedPermanentCalculator.h"
 #include <fstream>
 #include <iostream>

--- a/piquassoboost/sampling/source/GlynnPermanentCalculatorRepeatedDFE.cpp
+++ b/piquassoboost/sampling/source/GlynnPermanentCalculatorRepeatedDFE.cpp
@@ -1,5 +1,5 @@
 #include "GlynnPermanentCalculatorRepeatedDFE.h"
-#include "GlynnPermanentCalculatorRepeated.h"
+#include "GlynnPermanentCalculatorRepeated.hpp"
 #include "BatchedPermanentCalculator.h"
 #include <fstream>
 #include <iostream>
@@ -619,7 +619,7 @@ cGlynnPermanentCalculatorRepeatedMulti_DFE::calculate(size_t batch_idx, size_t b
     matrix perms(1, batch_iterations[batch_idx]);
 
     if (doCPU) { //compute with other method
-        GlynnPermanentCalculatorRepeated gpc;
+        GlynnPermanentCalculatorRepeatedLongDouble gpc;
         for ( size_t idx=0; idx<batch_iterations[batch_idx]; idx++) {
             perms[idx] = gpc.calculate(matrix_init, input_states[idx+batch_index_offset], output_state);
         }
@@ -737,7 +737,7 @@ GlynnPermanentCalculatorRepeatedMulti_DFE(matrix& matrix_init, PicState_int64& i
     }
     if (!((!useFloat && calcPermanentGlynnDFE) || (useFloat && calcPermanentGlynnDFEF)) ||
         photons < 1+dfe_basekernpow2) { //compute with other method
-      GlynnPermanentCalculatorRepeated gpc;
+      GlynnPermanentCalculatorRepeatedLongDouble gpc;
       perm = gpc.calculate(matrix_init, input_state, output_state);
       unlock_lib();
       return;
@@ -781,7 +781,7 @@ GlynnPermanentCalculatorRepeatedMulti_DFE(matrix& matrix_init, PicState_int64& i
         totalPerms *= (adj_input_state[mrows[i]] + 1);
     }
     if (onerows < 1+dfe_basekernpow2) { //compute with other method
-      GlynnPermanentCalculatorRepeated gpc;
+      GlynnPermanentCalculatorRepeatedLongDouble gpc;
       perm = gpc.calculate(matrix_init, input_state, output_state);
       unlock_lib();
       return;
@@ -1096,7 +1096,7 @@ GlynnPermanentCalculatorRepeated_DFE(matrix& matrix_init, PicState_int64& input_
         t1 *= (input_state[i]+1); t2 *= (output_state[i]+1);
     }
     if (!calcPermanentGlynnRepDFE || photons < 1+dfe_basekernpow2) { //compute with other method
-      GlynnPermanentCalculatorRepeated gpc;
+      GlynnPermanentCalculatorRepeatedLongDouble gpc;
       perm = gpc.calculate(matrix_init, input_state, output_state);
       unlock_lib();
       return;

--- a/piquassoboost/sampling/source/GlynnPermanentCalculators_implementation.cpp
+++ b/piquassoboost/sampling/source/GlynnPermanentCalculators_implementation.cpp
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2022 Budapest Quantum Computing Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "GlynnPermanentCalculator.hpp"
+#include "GlynnPermanentCalculatorRepeated.hpp"
+
+namespace pic{
+
+template class GlynnPermanentCalculator<pic::matrix32, long double>;
+template class GlynnPermanentCalculator<pic::matrix, double>;
+template class GlynnPermanentCalculatorRepeated<pic::matrix, double>;
+template class GlynnPermanentCalculatorRepeated<pic::matrix32, long double>;
+
+
+} // namespace pic
+


### PR DESCRIPTION
Permanent calculators from CPU side were updated with the property that they can be used with different precisions.

Python script and python interfaces were updated.

Refactoring function binomialCoeff to calculate the coefficient with larger integer datatypes.