### PR TITLE
FIX(conftest): Incorrect test discovery + feat: Update piquasso to version 2.0.0

### DIFF
--- a/boson_sampling_benchmark.py
+++ b/boson_sampling_benchmark.py
@@ -1,17 +1,17 @@
 #
-#  Copyright 2021 Budapest Quantum Computing Group
+# Copyright 2021-2022 Budapest Quantum Computing Group
 #
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import time
 import pytest

--- a/bs_test_with_losses.py
+++ b/bs_test_with_losses.py
@@ -1,17 +1,17 @@
 #
-#  Copyright 2021 Budapest Quantum Computing Group
+# Copyright 2021-2022 Budapest Quantum Computing Group
 #
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 try:
     from mpi4py import MPI

--- a/conftest.py
+++ b/conftest.py
@@ -26,7 +26,8 @@ def _patch(request):
 
     result = regexp.search(str(request.fspath))
 
-    if result.group(1) == "piquasso-module":
-        # NOTE: Only override the simulators, when the origin Piquasso Python tests are
-        # executed. For tests originating in PiquassoBoost, handle everything manually!
+    if result.group(1) in ["tests", "scripts", "piquasso-module"]:
+        # NOTE: Only override the simulators, when the original Piquasso Python tests
+        # are executed. For tests originating in PiquassoBoost, handle everything
+        # manually!
         pqb.patch()

--- a/permanent_benchmark.py
+++ b/permanent_benchmark.py
@@ -1,3 +1,18 @@
+#
+# Copyright 2021-2022 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import numpy as np
 from thewalrus import perm
 from piquassoboost.sampling.Boson_Sampling_Utilities import ChinHuhPermanentCalculator, GlynnPermanent, GlynnPermanentDouble, GlynnRepeatedPermanentCalculator, GlynnPermanentSingleDFE, GlynnPermanentDualDFE, GlynnPermanentInf, GlynnRepeatedPermanentCalculatorDouble, BBFGRepeatedPermanentCalculatorDouble, BBFGRepeatedPermanentCalculatorLongDouble, BBFGPermanentLongDouble, BBFGPermanentDouble, GlynnRepeatedSingleDFEPermanentCalculator, GlynnRepeatedInfPermanentCalculator

--- a/piquassoboost/__init__.py
+++ b/piquassoboost/__init__.py
@@ -16,6 +16,7 @@
 import piquasso as pq
 
 from piquassoboost.config import BoostConfig
+from piquassoboost.calculator import BoostCalculator
 
 from piquassoboost.gaussian.simulator import BoostedGaussianSimulator
 from piquassoboost.sampling.simulator import BoostedSamplingSimulator
@@ -30,6 +31,7 @@ def patch():
     pq.BoostedFockSimulator = BoostedFockSimulator
 
     pq.BoostConfig = BoostConfig
+    pq.BoostCalculator = BoostCalculator
 
     pq.GaussianSimulator = BoostedGaussianSimulator
     pq.SamplingSimulator = BoostedSamplingSimulator

--- a/piquassoboost/calculator.py
+++ b/piquassoboost/calculator.py
@@ -1,0 +1,58 @@
+#
+# Copyright 2021-2022 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from piquasso._backends.calculator import NumpyCalculator
+
+from piquassoboost.sampling.Boson_Sampling_Utilities import (
+    PowerTraceLoopHafnian,
+    GlynnPermanent
+)
+
+from theboss.boson_sampling_utilities.boson_sampling_utilities import (
+    EffectiveScatteringMatrixCalculator
+)
+
+from piquasso._math.hafnian import _reduce_matrix_with_diagonal
+
+
+def cpp_loop_hafnian(matrix, diagonal, reduce_on):
+    reduced_matrix = _reduce_matrix_with_diagonal(matrix, diagonal, reduce_on)
+
+    return PowerTraceLoopHafnian(reduced_matrix).calculate()
+
+
+def cpp_permanent_function(matrix, input, output):
+    scattering_matrix = EffectiveScatteringMatrixCalculator(
+        matrix, input, output
+    ).calculate()
+
+    calculator = GlynnPermanent(scattering_matrix)
+
+    result = calculator.calculate()
+
+    if isinstance(result, list):
+        # TODO: Here an empty list is passed instead of 1.0.
+        result = 1.0
+
+    return result
+
+
+class BoostCalculator(NumpyCalculator):
+    def __init__(self) -> None:
+        super().__init__()
+
+        self.permanent = cpp_permanent_function
+        self.loop_hafnian = cpp_loop_hafnian
+        self.number_of_approximated_modes = None

--- a/piquassoboost/config.py
+++ b/piquassoboost/config.py
@@ -24,9 +24,13 @@ from theboss.boson_sampling_utilities.boson_sampling_utilities import (
     EffectiveScatteringMatrixCalculator
 )
 
+from piquasso._math.hafnian import _reduce_matrix_with_diagonal
 
-def cpp_loop_hafnian(matrix):
-    return PowerTraceLoopHafnian(matrix).calculate()
+
+def cpp_loop_hafnian(matrix, diagonal, reduce_on):
+    reduced_matrix = _reduce_matrix_with_diagonal(matrix, diagonal, reduce_on)
+
+    return PowerTraceLoopHafnian(reduced_matrix).calculate()
 
 
 def cpp_permanent_function(matrix, input, output):
@@ -36,7 +40,13 @@ def cpp_permanent_function(matrix, input, output):
 
     calculator = GlynnPermanent(scattering_matrix)
 
-    return calculator.calculate()
+    result = calculator.calculate()
+
+    if isinstance(result, list):
+        # TODO: Here an empty list is passed instead of 1.0.
+        result = 1.0
+
+    return result
 
 
 class BoostConfig(Config):

--- a/piquassoboost/config.py
+++ b/piquassoboost/config.py
@@ -15,50 +15,9 @@
 
 from piquasso.api.config import Config
 
-from piquassoboost.sampling.Boson_Sampling_Utilities import (
-    PowerTraceLoopHafnian,
-    GlynnPermanent
-)
-
-from theboss.boson_sampling_utilities.boson_sampling_utilities import (
-    EffectiveScatteringMatrixCalculator
-)
-
-from piquasso._math.hafnian import _reduce_matrix_with_diagonal
-
-
-def cpp_loop_hafnian(matrix, diagonal, reduce_on):
-    reduced_matrix = _reduce_matrix_with_diagonal(matrix, diagonal, reduce_on)
-
-    return PowerTraceLoopHafnian(reduced_matrix).calculate()
-
-
-def cpp_permanent_function(matrix, input, output):
-    scattering_matrix = EffectiveScatteringMatrixCalculator(
-        matrix, input, output
-    ).calculate()
-
-    calculator = GlynnPermanent(scattering_matrix)
-
-    result = calculator.calculate()
-
-    if isinstance(result, list):
-        # TODO: Here an empty list is passed instead of 1.0.
-        result = 1.0
-
-    return result
-
 
 class BoostConfig(Config):
-    def __init__(
-        self,
-        loop_hafnian_function=cpp_loop_hafnian,
-        permanent_function=cpp_permanent_function,
-        **kwargs,
-    ) -> None:
-        super().__init__(
-            loop_hafnian_function=loop_hafnian_function,
-            permanent_function=permanent_function,
-            **kwargs,
-        )
-        self.number_of_approximated_modes = None
+    def __init__(self, number_of_approximated_modes=None, **kwargs) -> None:
+        super().__init__(**kwargs)
+
+        self.number_of_approximated_modes = number_of_approximated_modes

--- a/piquassoboost/fock/general/simulator.py
+++ b/piquassoboost/fock/general/simulator.py
@@ -15,8 +15,8 @@
 
 import piquasso as pq
 
-from piquassoboost.config import BoostConfig
+from piquassoboost.calculator import BoostCalculator
 
 
 class BoostedFockSimulator(pq.FockSimulator):
-    _config_class = BoostConfig
+    _calculator_class = BoostCalculator

--- a/piquassoboost/fock/pure/simulator.py
+++ b/piquassoboost/fock/pure/simulator.py
@@ -16,7 +16,9 @@
 import piquasso as pq
 
 from piquassoboost.config import BoostConfig
+from piquassoboost.calculator import BoostCalculator
 
 
 class BoostedPureFockSimulator(pq.PureFockSimulator):
     _config_class = BoostConfig
+    _calculator_class = BoostCalculator

--- a/piquassoboost/gaussian/simulator.py
+++ b/piquassoboost/gaussian/simulator.py
@@ -18,6 +18,7 @@ import piquasso as pq
 from piquasso.instructions import gates, measurements
 
 from piquassoboost.config import BoostConfig
+from piquassoboost.calculator import BoostCalculator
 
 from .calculations import passive_linear, threshold_measurement, particle_number_measurement
 
@@ -34,3 +35,4 @@ class BoostedGaussianSimulator(pq.GaussianSimulator):
     }
 
     _config_class = BoostConfig
+    _calculator_class = BoostCalculator

--- a/piquassoboost/sampling/Boson_Sampling_Utilities.py
+++ b/piquassoboost/sampling/Boson_Sampling_Utilities.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Budapest Quantum Computing Group
+# Copyright 2021-2022 Budapest Quantum Computing Group
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/piquassoboost/sampling/simulator.py
+++ b/piquassoboost/sampling/simulator.py
@@ -18,6 +18,7 @@ import piquasso as pq
 from piquasso.instructions import measurements
 
 from piquassoboost.config import BoostConfig
+from piquassoboost.calculator import BoostCalculator
 
 from .calculations import particle_number_measurement
 
@@ -29,3 +30,4 @@ class BoostedSamplingSimulator(pq.SamplingSimulator):
     }
 
     _config_class = BoostConfig
+    _calculator_class = BoostCalculator

--- a/piquassoboost/sampling/simulator.py
+++ b/piquassoboost/sampling/simulator.py
@@ -17,6 +17,8 @@ import piquasso as pq
 
 from piquasso.instructions import measurements
 
+from piquassoboost.config import BoostConfig
+
 from .calculations import particle_number_measurement
 
 
@@ -25,3 +27,5 @@ class BoostedSamplingSimulator(pq.SamplingSimulator):
         **pq.SamplingSimulator._instruction_map,
         measurements.ParticleNumberMeasurement: particle_number_measurement,
     }
+
+    _config_class = BoostConfig

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "numpy>=1.19.4",
-        "piquasso==1.0.0",
+        "piquasso==2.0.0",
     ],
     tests_require=["pytest"],
     description='The C++ binding for the Piquasso project',


### PR DESCRIPTION
In commit `cb8c1c4181812942b8413c9c55820f4de654f9b2`, `piquasso` has 
been updated to `1.0.0`. In it, the pytest got updated from version 5 to 
version 7. Unfortunately, version 7 handles symbolic links differently. 
 
For tests under `piquasso-module`, `piquasso` is patched with classes 
from `piquassoboost` automatically. But the `piqussso-module/tests` 
module has a symbolic link `tests` in the `piquassoboost` root folder. 
 
Previously, `pytest`'s `request.fspath` was the original location of the 
test, but in version 7 it changed to be the symbolically linked path 
instead. 
 
Since this update, when a developer ran `pytest tests`, the original 
`piquasso` was used instead of `piquassoboost`. This has been corrected 
in this patch. 
 
There were several failing tests, and fixing them required only minor 
changes in the Python code. 