### PR TITLE
bump(piquasso): 4.0.0 -> 5.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,7 @@ piquassoboost.egg-info
 
 .vscode
 
+.venv*
+
 *.so
 *.so.*

--- a/boostbenchmarks/boson_sampling_benchmark.py
+++ b/boostbenchmarks/boson_sampling_benchmark.py
@@ -1,0 +1,163 @@
+import time
+
+import random
+
+import json
+
+import matplotlib.pyplot as plt
+
+import numpy as np
+
+import perceval as pcvl
+from perceval.algorithm import Sampler
+
+import piquasso as pq
+import piquassoboost as pqb
+
+
+N = 100  # number of samplings
+
+
+def Generating_Input(n, m):
+    "This function randomly chooses an input with n photons in m modes."
+    modes = sorted(random.sample(range(m), n))
+
+    state = "|"
+    for i in range(m):
+        state = (
+            state + "0" * (1 - (i in modes)) + "1" * (i in modes) + "," * (i < m - 1)
+        )
+    return pcvl.BasicState(state + ">")
+
+
+mzi = (
+    pcvl.BS()
+    // (0, pcvl.PS(phi=pcvl.Parameter("φ_a")))
+    // pcvl.BS()
+    // (1, pcvl.PS(phi=pcvl.Parameter("φ_b")))
+)
+
+
+def get_perceval_samples(unitary):
+    m = len(unitary)
+
+    n = m // 2
+
+    Linear_Circuit = pcvl.Circuit.decomposition(
+        unitary,
+        mzi,
+        phase_shifter_fn=pcvl.PS,
+        shape=pcvl.InterferometerShape.TRIANGLE,
+    )
+
+    QPU = pcvl.Processor("CliffordClifford2017", Linear_Circuit)
+
+    input_state = Generating_Input(n, m)
+    QPU.with_input(input_state)
+
+    # Keep all outputs
+    QPU.min_detected_photons_filter(0)
+
+    sampler = Sampler(QPU)
+
+    return sampler.samples(N)["results"]
+
+def generate_random_fock_state(m, n):
+    modes = sorted(random.sample(range(m), n))
+
+    state_vector = []
+    for i in range(m):
+        if i in modes:
+            state_vector.append(1)
+        else:
+            state_vector.append(0)
+
+    return state_vector
+
+
+def get_piquassoboost_samples(unitary):
+    m = len(unitary)
+    n = m // 2
+
+    input_state = generate_random_fock_state(m=m, n=n)
+    program = pq.Program(
+        instructions=[
+            pq.StateVector(input_state),
+            pq.Interferometer(unitary),
+            pq.ParticleNumberMeasurement(),
+        ]
+    )
+
+    simulator = pqb.BoostedSamplingSimulator(d=m)
+
+    return simulator.execute(program, shots=N).samples
+
+
+def get_piquasso_samples(unitary):
+    m = len(unitary)
+    n = m // 2
+
+    input_state = generate_random_fock_state(m=m, n=n)
+    program = pq.Program(
+        instructions=[
+            pq.StateVector(input_state),
+            pq.Interferometer(unitary),
+            pq.ParticleNumberMeasurement(),
+        ]
+    )
+
+    simulator = pq.SamplingSimulator(d=m)
+
+    return simulator.execute(program, shots=N).samples
+
+
+if __name__ == "__main__":
+
+    # Warmup
+    m = 2
+    unitary = pcvl.Matrix.random_unitary(m)
+    get_perceval_samples(unitary)
+    get_piquasso_samples(np.array(unitary))
+    ####
+
+    FILENAME = f"boson_sampling_{int(time.time())}.json"
+
+    x = []
+    pv_times = []
+    pq_times = []
+    pqb_times = []
+
+    for m in range(2, 30):
+        print("m:", m)
+        x.append(m)
+        unitary = pcvl.Matrix.random_unitary(m)
+
+        start_time = time.time()
+        get_perceval_samples(unitary)
+        runtime = time.time() - start_time
+        print("PV:", runtime)
+        pv_times.append(runtime)
+
+        start_time = time.time()
+        get_piquassoboost_samples(np.array(unitary))
+        runtime = time.time() - start_time
+        print("PQB:", runtime)
+        pqb_times.append(runtime)
+
+        start_time = time.time()
+        get_piquasso_samples(np.array(unitary))
+        runtime = time.time() - start_time
+        print("PQ:", runtime)
+        pq_times.append(runtime)
+
+        with open(FILENAME, "w") as f:
+            json.dump(dict(x=x, pqb_times=pqb_times, pv_times=pv_times, pq_times=pq_times), f)
+
+    plt.scatter(x, pv_times, label="Perceval")
+    plt.scatter(x, pqb_times, label="PiquassoBoost")
+    plt.scatter(x, pq_times, label="Piquasso")
+
+    plt.yscale("log")
+
+    plt.legend()
+    plt.show()

--- a/boostbenchmarks/permanent_benchmark.py
+++ b/boostbenchmarks/permanent_benchmark.py
@@ -1,0 +1,94 @@
+from piquasso._math.permanent import permanent
+
+from piquassoboost.connector import cpp_permanent_function
+
+
+
+#
+# Copyright 2021-2024 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Benchmarking the Piquasso vs. TheWalrus hafnian with repetitions.
+"""
+
+import time
+
+import json
+
+from piquasso._math.permanent import permanent
+
+import matplotlib.pyplot as plt
+
+import numpy as np
+
+np.set_printoptions(suppress=True, linewidth=200)
+
+
+if __name__ == "__main__":
+    x = []
+    y = []
+    z = []
+
+    ITER = 100
+
+    FILENAME = f"permanent_benchmark_{int(time.time())}.json"
+
+    # Compilation
+    d = 2
+    A = np.random.rand(d, d) + 1j * np.random.rand(d, d)
+    A = A + A.T
+    occupation_numbers = 2 * np.ones(d, dtype=int)
+    permanent(A, occupation_numbers, occupation_numbers)
+    cpp_permanent_function(A, occupation_numbers, occupation_numbers)
+    ###
+
+    for d in range(2, 12 + 1):
+        print(d)
+        x.append(d)
+        A = np.random.rand(d, d) + 1j * np.random.rand(d, d)
+
+        A = A + A.T
+
+        occupation_numbers = 2 * np.ones(d, dtype=int)
+
+        sum_ = 0.0
+        for _ in range(ITER):
+            print("|", end="", flush=True)
+            start_time = time.time()
+            permanent(A, occupation_numbers, occupation_numbers)
+            sum_ += time.time() - start_time
+        y.append(sum_ / ITER)
+        print()
+
+        sum_ = 0.0
+        for _ in range(ITER):
+            print("/", end="", flush=True)
+            start_time = time.time()
+            cpp_permanent_function(A, occupation_numbers, occupation_numbers)
+            sum_ += time.time() - start_time
+        z.append(sum_ / ITER)
+        print()
+
+        with open(FILENAME, "w") as f:
+            json.dump(dict(x=x, y=y, z=z), f, indent=4)
+
+    plt.scatter(x, y, label="Piquasso")
+    plt.scatter(x, z, label="PiquassoBoost")
+    plt.legend()
+    plt.yscale("log")
+    plt.xlabel("d [-]")
+    plt.ylabel("Execution time [s]")
+
+    plt.show()

--- a/piquassoboost/__init__.py
+++ b/piquassoboost/__init__.py
@@ -16,7 +16,7 @@
 import piquasso as pq
 
 from piquassoboost.config import BoostConfig
-from piquassoboost.calculator import BoostCalculator
+from piquassoboost.connector import BoostConnector
 
 from piquassoboost.gaussian.simulator import BoostedGaussianSimulator
 from piquassoboost.sampling.simulator import BoostedSamplingSimulator
@@ -31,7 +31,7 @@ def patch():
     pq.BoostedFockSimulator = BoostedFockSimulator
 
     pq.BoostConfig = BoostConfig
-    pq.BoostCalculator = BoostCalculator
+    pq.BoostConnector = BoostConnector
 
     pq.GaussianSimulator = BoostedGaussianSimulator
     pq.SamplingSimulator = BoostedSamplingSimulator
@@ -40,4 +40,4 @@ def patch():
 
     pq.Config = BoostConfig
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/piquassoboost/connector.py
+++ b/piquassoboost/connector.py
@@ -13,34 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from piquasso._backends.calculator import NumpyCalculator
+from piquasso._simulators.connectors import NumpyConnector
 
 from piquassoboost.sampling.Boson_Sampling_Utilities import (
-    PowerTraceLoopHafnian,
-    GlynnPermanent
+    BBFGRepeatedPermanentCalculatorDouble,
 )
-
-from theboss.boson_sampling_utilities.boson_sampling_utilities import (
-    EffectiveScatteringMatrixCalculator
-)
-
-from piquasso._math.hafnian import _reduce_matrix_with_diagonal
-
-
-def cpp_loop_hafnian(matrix, diagonal, reduce_on):
-    reduced_matrix = _reduce_matrix_with_diagonal(matrix, diagonal, reduce_on)
-
-    return PowerTraceLoopHafnian(reduced_matrix).calculate()
 
 
 def cpp_permanent_function(matrix, input, output):
-    scattering_matrix = EffectiveScatteringMatrixCalculator(
-        matrix, input, output
-    ).calculate()
 
-    calculator = GlynnPermanent(scattering_matrix)
-
-    result = calculator.calculate()
+    result = BBFGRepeatedPermanentCalculatorDouble(matrix, input, output).calculate()
 
     if isinstance(result, list):
         # TODO: Here an empty list is passed instead of 1.0.
@@ -49,10 +31,9 @@ def cpp_permanent_function(matrix, input, output):
     return result
 
 
-class BoostCalculator(NumpyCalculator):
+class BoostConnector(NumpyConnector):
     def __init__(self) -> None:
         super().__init__()
 
         self.permanent = cpp_permanent_function
-        self.loop_hafnian = cpp_loop_hafnian
         self.number_of_approximated_modes = None

--- a/piquassoboost/fock/general/simulator.py
+++ b/piquassoboost/fock/general/simulator.py
@@ -15,8 +15,8 @@
 
 import piquasso as pq
 
-from piquassoboost.calculator import BoostCalculator
+from piquassoboost.connector import BoostConnector
 
 
 class BoostedFockSimulator(pq.FockSimulator):
-    _calculator_class = BoostCalculator
+    _connector_class = BoostConnector

--- a/piquassoboost/fock/pure/simulator.py
+++ b/piquassoboost/fock/pure/simulator.py
@@ -16,9 +16,9 @@
 import piquasso as pq
 
 from piquassoboost.config import BoostConfig
-from piquassoboost.calculator import BoostCalculator
+from piquassoboost.connector import BoostConnector
 
 
 class BoostedPureFockSimulator(pq.PureFockSimulator):
     _config_class = BoostConfig
-    _calculator_class = BoostCalculator
+    _connector_class = BoostConnector

--- a/piquassoboost/gaussian/calculations.py
+++ b/piquassoboost/gaussian/calculations.py
@@ -13,53 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Tuple
-
 import numpy as np
 
-import piquasso as pq
-
-from .calculation_extension import apply_passive_linear_to_C_and_G
-
 from piquasso.api.result import Result
-from piquasso._backends.gaussian import calculations as pq_calculations
+from piquasso._simulators.gaussian import calculations as pq_calculations
 
 from piquassoboost.sampling.simulation_strategies import ThresholdBosonSampling
-
-
-def passive_linear(
-    state, instruction, shots
-):
-    modes = instruction.modes
-    T: np.ndarray = instruction._get_passive_block(state._calculator, state._config)
-
-    # NOTE: We need to explicitely cast complex64 to complex128 for piquassoboost to
-    # handle it correctly, and then cast it back.
-    dtype_is_complex64 = state._C.dtype == np.complex64
-
-    if dtype_is_complex64:
-        state._C = state._C.astype(np.complex128)
-        state._G = state._G.astype(np.complex128)
-        T = T.astype(np.complex128)
-
-    state._m[(modes,)] = (
-        T
-        @ state._m[
-            modes,
-        ]
-    )
-
-    apply_passive_linear_to_C_and_G(
-        C=state._C, G=state._G,
-        T=T, modes=modes,
-    )
-
-    if dtype_is_complex64:
-        state._C = state._C.astype(np.complex64)
-        state._G = state._G.astype(np.complex64)
-        T = T.astype(np.complex64)
-
-    return Result(state=state)
 
 
 def threshold_measurement(state, instruction, shots):
@@ -68,27 +27,15 @@ def threshold_measurement(state, instruction, shots):
     """
 
     if not np.allclose(state.xpxp_mean_vector, np.zeros_like(state.xpxp_mean_vector)):
-        raise NotImplementedError(
-            "Threshold measurement for displaced states are not supported: "
-            f"xpxp_mean_vector={state.xpxp_mean_vector}"
-        )
+        return pq_calculations.threshold_measurement(state, instruction, shots)
 
     reduced_state = state.reduced(instruction.modes)
 
     th = ThresholdBosonSampling.ThresholdBosonSampling(
         covariance_matrix=(
-            reduced_state.xxpp_covariance_matrix
-            / (2 * state._config.hbar)
+            reduced_state.xxpp_covariance_matrix / (2 * state._config.hbar)
         )
     )
     samples = th.simulate(shots)
-
-    return Result(state=state, samples=samples)
-
-
-def particle_number_measurement(state, instruction, shots) -> Result:
-    samples = pq_calculations._get_particle_number_measurement_samples(
-        state, instruction, shots
-    )
 
     return Result(state=state, samples=samples)

--- a/piquassoboost/gaussian/simulator.py
+++ b/piquassoboost/gaussian/simulator.py
@@ -15,24 +15,18 @@
 
 import piquasso as pq
 
-from piquasso.instructions import gates, measurements
+from piquasso.instructions import measurements
 
 from piquassoboost.config import BoostConfig
-from piquassoboost.calculator import BoostCalculator
+from piquassoboost.connector import BoostConnector
 
-from .calculations import passive_linear, threshold_measurement, particle_number_measurement
+from .calculations import threshold_measurement
 
 class BoostedGaussianSimulator(pq.GaussianSimulator):
     _instruction_map = {
         **pq.GaussianSimulator._instruction_map,
-        gates.Interferometer: passive_linear,
-        gates.Beamsplitter: passive_linear,
-        gates.Phaseshifter: passive_linear,
-        gates.MachZehnder: passive_linear,
-        gates.Fourier: passive_linear,
         measurements.ThresholdMeasurement: threshold_measurement,
-        measurements.ParticleNumberMeasurement: particle_number_measurement,
     }
 
     _config_class = BoostConfig
-    _calculator_class = BoostCalculator
+    _connector_class = BoostConnector

--- a/piquassoboost/sampling/simulator.py
+++ b/piquassoboost/sampling/simulator.py
@@ -18,7 +18,7 @@ import piquasso as pq
 from piquasso.instructions import measurements
 
 from piquassoboost.config import BoostConfig
-from piquassoboost.calculator import BoostCalculator
+from piquassoboost.connector import BoostConnector
 
 from .calculations import particle_number_measurement
 
@@ -30,4 +30,4 @@ class BoostedSamplingSimulator(pq.SamplingSimulator):
     }
 
     _config_class = BoostConfig
-    _calculator_class = BoostCalculator
+    _connector_class = BoostConnector

--- a/piquassoboost/sampling/source/PowerTraceHafnianUtilities.cpp
+++ b/piquassoboost/sampling/source/PowerTraceHafnianUtilities.cpp
@@ -22,8 +22,6 @@
 #include "loop_correction_AVX.h"
 
 
-long double sqrt(long double arg) { return sqrtl(arg); }
-
 namespace pic {
 
 /**

--- a/piquassoboost/sampling/source/PowerTraceHafnianUtilities.hpp
+++ b/piquassoboost/sampling/source/PowerTraceHafnianUtilities.hpp
@@ -38,8 +38,6 @@ static double time_szamlalo = 0.0;
 static double time_nevezo = 0.0;
 */
 
-long double sqrt(long double arg);
-
 namespace pic {
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ wheel
 scikit-build
 cmake
 ninja
-numpy
+numpy<2.0.0
 tbb-devel
-mpi4py
 networkx
+mpi4py

--- a/setup.py
+++ b/setup.py
@@ -27,14 +27,14 @@ setup(
             "piquasso", "piquasso.*",
         )
     ),
-    version='0.2.0',
-    url="https://gitlab.inf.elte.hu/wigner-rcp-quantum-computing-and-information-group/piquassoboost",  # noqa: E501
+    version='0.3.0',
+    url="https://github.com/Budapest-Quantum-Computing-Group/piquasso",  # noqa: E501
     maintainer="The Piquasso team",
     maintainer_email="kolarovszki@inf.elte.hu",
     include_package_data=True,
     install_requires=[
         "numpy>=1.19.4",
-        "piquasso==4.0.0",
+        "piquasso==5.0.0",
     ],
     tests_require=["pytest"],
     description='The C++ binding for the Piquasso project',


### PR DESCRIPTION
Piquasso got updated to version 5.0.0. Some calculations that have been moved to Piquasso have been unregistered.

Also, a permanent benchmark script and a boson sampling benchmark script is added.